### PR TITLE
Implicit card modifiers

### DIFF
--- a/data-format-description.ts
+++ b/data-format-description.ts
@@ -7,10 +7,9 @@ interface CardDescription {
     weight: number
 }
 
-interface CardActionData {
-    description?: string
+interface GameWorldModifier {
     modifierType?: 'add' | 'set' | 'replace'
-    modifier?: {
+    state?: {
         environment?: number
         people?: number
         security?: number
@@ -19,6 +18,10 @@ interface CardActionData {
     flags?: {
         [x: string]: boolean
     }
+}
+
+interface CardActionData extends GameWorldModifier {
+    description?: string
 }
 
 interface CardData extends CardDescription {

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -130,9 +130,19 @@ export default class Game extends Component {
         this.setState({ card: nextCard })
     }
 
-    getUpdatedWorld({ modifier = {}, flags = {}, modifierType = 'add' }) {
-        const updatedWorldState = this.updateWorldState(modifier, modifierType)
-        const updatedWorldFlags = this.updateWorldFlags(flags, modifierType)
+    getUpdatedWorld({
+        state: stateModifier = {},
+        flags: flagsModifier = {},
+        modifierType = 'add'
+    }) {
+        const updatedWorldState = this.updateWorldState(
+            stateModifier,
+            modifierType
+        )
+        const updatedWorldFlags = this.updateWorldFlags(
+            flagsModifier,
+            modifierType
+        )
 
         return {
             state: updatedWorldState,
@@ -140,13 +150,13 @@ export default class Game extends Component {
         }
     }
 
-    updateWorldState(modifier, modifierType) {
+    updateWorldState(stateModifier, modifierType) {
         const currentWorldState =
             modifierType === 'replace'
                 ? Object.assign({}, DEFAULT_GAME_WORLD.state)
                 : Object.assign({}, this.state.world.state)
 
-        const updatedWorldState = Object.entries(modifier).reduce(
+        const updatedWorldState = Object.entries(stateModifier).reduce(
             (updatedState, [key, value]) => {
                 const newValue =
                     modifierType === 'set' || modifierType === 'replace'
@@ -163,15 +173,15 @@ export default class Game extends Component {
         return updatedWorldState
     }
 
-    updateWorldFlags(flags, modifierType) {
+    updateWorldFlags(flagsModifier, modifierType) {
         const currentWorldFlags =
             modifierType === 'replace'
                 ? Object.assign({}, DEFAULT_GAME_WORLD.flags)
                 : Object.assign({}, this.state.world.flags)
 
-        const updatedWorldFlags = Object.keys(flags).reduce(
+        const updatedWorldFlags = Object.keys(flagsModifier).reduce(
             (updatedFlags, key) => {
-                updatedFlags[key] = flags[key]
+                updatedFlags[key] = flagsModifier[key]
                 return updatedFlags
             },
             currentWorldFlags

--- a/src/data/cards.js
+++ b/src/data/cards.js
@@ -13,7 +13,7 @@ export default [
         ],
         actions: {
             left: {
-                modifier: {
+                state: {
                     environment: -100,
                     people: -100,
                     security: -100,
@@ -21,7 +21,7 @@ export default [
                 }
             },
             right: {
-                modifier: {
+                state: {
                     environment: 40,
                     people: 60,
                     security: 75,
@@ -44,7 +44,7 @@ export default [
         ],
         actions: {
             left: {
-                modifier: {
+                state: {
                     environment: -100,
                     people: -100,
                     security: -100,
@@ -52,11 +52,11 @@ export default [
                 }
             },
             right: {
-                modifier: {
+                state: {
                     environment: 40,
                     people: 60,
                     security: 75,
-                    money: 90
+                    money: 0
                 }
             }
         }

--- a/src/data/event-cards.js
+++ b/src/data/event-cards.js
@@ -10,7 +10,7 @@ export default {
         actions: {
             left: {
                 modifierType: 'replace',
-                modifier: {
+                state: {
                     environment: 10,
                     people: 10,
                     security: 10
@@ -20,7 +20,7 @@ export default {
             },
             right: {
                 modifierType: 'replace',
-                modifier: {
+                state: {
                     environment: 10,
                     people: 10,
                     security: 10


### PR DESCRIPTION
**This is one of two alternatives**

`modifiers` should be renamed to `state` to show what they modify

By using the type (interface) GameWorldModifier, card modifiers
object can be implicit in the card data