### PR TITLE
Explicit `modifier` on cards to group changes better

### DIFF
--- a/data-format-description.ts
+++ b/data-format-description.ts
@@ -7,8 +7,6 @@ interface CardDescription {
     weight: number
 }
 
-// TODO: decide if these potential changes are wanted or not.
-
 interface GameWorldModifier {
     modifierType?: 'add' | 'set' | 'replace'
     state?: {

--- a/data-format-description.ts
+++ b/data-format-description.ts
@@ -7,10 +7,11 @@ interface CardDescription {
     weight: number
 }
 
-interface CardActionData {
-    description?: string
+// TODO: decide if these potential changes are wanted or not.
+
+interface GameWorldModifier {
     modifierType?: 'add' | 'set' | 'replace'
-    modifier?: {
+    state?: {
         environment?: number
         people?: number
         security?: number
@@ -19,6 +20,11 @@ interface CardActionData {
     flags?: {
         [x: string]: boolean
     }
+}
+
+interface CardActionData {
+    description?: string
+    modifier: GameWorldModifier
 }
 
 interface CardData extends CardDescription {

--- a/data-format-description.ts
+++ b/data-format-description.ts
@@ -8,7 +8,7 @@ interface CardDescription {
 }
 
 interface GameWorldModifier {
-    modifierType?: 'add' | 'set' | 'replace'
+    type?: 'add' | 'set' | 'replace'
     state?: {
         environment?: number
         people?: number

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -63,7 +63,7 @@ export default class Game extends Component {
             card: this.selectNextCard(
                 this.getAvailableCards(DEFAULT_GAME_WORLD)
             ),
-            rounds: 0,
+            rounds: 0
         }
     }
 
@@ -109,7 +109,7 @@ export default class Game extends Component {
         this.setState({
             world: updatedWorld,
             card: this.getNextCard(updatedWorld, card, currentAction),
-            rounds: this.state.rounds + 1,
+            rounds: this.state.rounds + 1
         })
     }
 
@@ -142,9 +142,12 @@ export default class Game extends Component {
         return nextCard
     }
 
-    getUpdatedWorld({ modifier = {}, flags = {}, modifierType = 'add' }) {
-        const updatedWorldState = this.updateWorldState(modifier, modifierType)
-        const updatedWorldFlags = this.updateWorldFlags(flags, modifierType)
+    getUpdatedWorld({ type = 'add', state = {}, flags = {} }) {
+        // get default values for missing props by destructuring the incoming `modifier` and then directly reassembling it
+        // IDEA: Could this all be done in the function declaration, when specifying parameters?
+        const modifier = { type, state, flags }
+        const updatedWorldState = this.updateWorldState(modifier)
+        const updatedWorldFlags = this.updateWorldFlags(modifier)
 
         return {
             state: updatedWorldState,
@@ -152,16 +155,16 @@ export default class Game extends Component {
         }
     }
 
-    updateWorldState(modifier, modifierType) {
+    updateWorldState(modifier) {
         const currentWorldState =
-            modifierType === 'replace'
+            modifier.type === 'replace'
                 ? Object.assign({}, DEFAULT_GAME_WORLD.state)
                 : Object.assign({}, this.state.world.state)
 
-        const updatedWorldState = Object.entries(modifier).reduce(
+        const updatedWorldState = Object.entries(modifier.state).reduce(
             (updatedState, [key, value]) => {
                 const newValue =
-                    modifierType === 'set' || modifierType === 'replace'
+                    modifier.type === 'set' || modifier.type === 'replace'
                         ? value
                         : value + (updatedState[key] || 0)
 
@@ -175,15 +178,15 @@ export default class Game extends Component {
         return updatedWorldState
     }
 
-    updateWorldFlags(flags, modifierType) {
+    updateWorldFlags(modifier) {
         const currentWorldFlags =
-            modifierType === 'replace'
+            modifier.type === 'replace'
                 ? Object.assign({}, DEFAULT_GAME_WORLD.flags)
                 : Object.assign({}, this.state.world.flags)
 
-        const updatedWorldFlags = Object.keys(flags).reduce(
+        const updatedWorldFlags = Object.keys(modifier.flags).reduce(
             (updatedFlags, key) => {
-                updatedFlags[key] = flags[key]
+                updatedFlags[key] = modifier.flags[key]
                 return updatedFlags
             },
             currentWorldFlags

--- a/src/data/cards.js
+++ b/src/data/cards.js
@@ -14,18 +14,24 @@ export default [
         actions: {
             left: {
                 modifier: {
-                    environment: -100,
-                    people: -100,
-                    security: -100,
-                    money: -100
+                    type: 'add',
+                    state: {
+                        environment: -100,
+                        people: -100,
+                        security: -100,
+                        money: -100
+                    }
                 }
             },
             right: {
                 modifier: {
-                    environment: 40,
-                    people: 60,
-                    security: 75,
-                    money: 90
+                    type: 'add',
+                    state: {
+                        environment: 40,
+                        people: 60,
+                        security: 75,
+                        money: 90
+                    }
                 }
             }
         }
@@ -45,18 +51,24 @@ export default [
         actions: {
             left: {
                 modifier: {
-                    environment: -100,
-                    people: -100,
-                    security: -100,
-                    money: -100
+                    type: 'add',
+                    state: {
+                        environment: -100,
+                        people: -100,
+                        security: -100,
+                        money: -100
+                    }
                 }
             },
             right: {
                 modifier: {
-                    environment: 40,
-                    people: 60,
-                    security: 75,
-                    money: 90
+                    type: 'add',
+                    state: {
+                        environment: 40,
+                        people: 60,
+                        security: 75,
+                        money: 90
+                    }
                 }
             }
         }

--- a/src/data/event-cards.js
+++ b/src/data/event-cards.js
@@ -9,23 +9,27 @@ export default {
         weight: 1000,
         actions: {
             left: {
-                modifierType: 'replace',
                 modifier: {
-                    environment: 10,
-                    people: 10,
-                    security: 10
+                    type: 'replace',
+                    state: {
+                        environment: 10,
+                        people: 10,
+                        security: 10
+                    },
+                    flags: {}
                 },
-                flags: {},
                 nextEventCardId: null
             },
             right: {
-                modifierType: 'replace',
                 modifier: {
-                    environment: 10,
-                    people: 10,
-                    security: 10
+                    type: 'replace',
+                    state: {
+                        environment: 10,
+                        people: 10,
+                        security: 10
+                    },
+                    flags: {}
                 },
-                flags: {},
                 nextEventCardId: null
             }
         }


### PR DESCRIPTION
**I think this approach is much better than #40**

This will significantly improve readability, and make both
code & data easier to understand.

This will add more fields to data-files, but since these will be automated
anyway, it won't hurt if they are easy to understand when
editing manually until then.

And if this format adds too much redundant weight for production
environment, we could find a optimized data format for
the prod version of the game.