### PR TITLE
WIP: Feature/keyboard events to swipe

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -3,6 +3,9 @@ import { animated, interpolate } from 'react-spring/hooks'
 import { useSpring } from 'react-spring/hooks'
 import { useGesture } from 'react-with-gesture'
 
+import { useKeyboardEvent } from '../util/hooks'
+import { SWIPE_DIRECTION } from '../data/constants'
+
 const to = i => ({
     x: 0,
     y: 0,
@@ -25,6 +28,21 @@ function Card({ i, cardData, onSwipe, layer }) {
 
     const [isGoneState] = useState({ isGone: false })
 
+    const handleSwipe = direction => {
+        isGoneState.isGone = true
+        window.setTimeout(() => {
+            onSwipe(cardData, direction)
+        }, 100)
+    }
+
+    // Allow desktop users to easily play the game
+    useKeyboardEvent('ArrowLeft', () => {
+        handleSwipe(SWIPE_DIRECTION.LEFT)
+    })
+    useKeyboardEvent('ArrowRight', () => {
+        handleSwipe(SWIPE_DIRECTION.RIGHT)
+    })
+
     const bind = useGesture(
         ({
             args: [index],
@@ -41,10 +59,7 @@ function Card({ i, cardData, onSwipe, layer }) {
 
             if (!down && trigger && !isGoneState.isGone) {
                 // Handle game state updates
-                isGoneState.isGone = true
-                window.setTimeout(() => {
-                    onSwipe(cardData, dir)
-                }, 100)
+                handleSwipe(dir)
             }
             const isGone = isGoneState.isGone
 

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -3,6 +3,7 @@ import styled from 'styled-components/macro'
 
 import Deck from './Deck'
 import Stats from './Stats'
+import { DEFAULT_GAME_WORLD, SWIPE_DIRECTION } from '../data/constants'
 
 // -------
 // TODO: Move to data loader module
@@ -22,21 +23,6 @@ const Footer = styled.footer`
     justify-content: center;
     align-items: center;
 `
-
-const DIRECTION = {
-    LEFT: -1,
-    RIGHT: 1,
-}
-
-const DEFAULT_GAME_WORLD = Object.freeze({
-    state: {
-        environment: 40,
-        people: 60,
-        security: 75,
-        money: 90,
-    },
-    flags: {},
-})
 
 export default class Game extends Component {
     state = this.getInitialState()
@@ -100,7 +86,7 @@ export default class Game extends Component {
 
     onSwipe(card, direction) {
         const currentAction =
-            direction === DIRECTION.LEFT
+            direction === SWIPE_DIRECTION.LEFT
                 ? card.actions.left
                 : card.actions.right
 

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -2,3 +2,13 @@ export const SWIPE_DIRECTION = {
     LEFT: -1,
     RIGHT: 1,
 }
+
+export const DEFAULT_GAME_WORLD = Object.freeze({
+    state: {
+        environment: 40,
+        people: 60,
+        security: 75,
+        money: 90,
+    },
+    flags: {},
+})

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1,0 +1,4 @@
+export const SWIPE_DIRECTION = {
+    LEFT: -1,
+    RIGHT: 1,
+}

--- a/src/util/hooks.js
+++ b/src/util/hooks.js
@@ -1,15 +1,22 @@
 import { useEffect } from 'react'
 
-export const useKeyboardEvent = (key, callback) => {
+export const useKeyboardEvent = (keys, callback) => {
     useEffect(() => {
-        const handler = function(event) {
-            if (event.key === key) {
-                callback()
+        const downHandler = function(event) {
+            if (keys.includes(event.key)) {
+                callback(true, event.key)
             }
         }
-        window.addEventListener('keydown', handler)
+        const upHandler = function(event) {
+            if (keys.includes(event.key)) {
+                callback(false, event.key)
+            }
+        }
+        window.addEventListener('keydown', downHandler)
+        window.addEventListener('keyup', upHandler)
         return () => {
-            window.removeEventListener('keydown', handler)
+            window.removeEventListener('keydown', downHandler)
+            window.removeEventListener('keyup', upHandler)
         }
     })
 }

--- a/src/util/hooks.js
+++ b/src/util/hooks.js
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+
+export const useKeyboardEvent = (key, callback) => {
+    useEffect(() => {
+        const handler = function(event) {
+            if (event.key === key) {
+                callback()
+            }
+        }
+        window.addEventListener('keydown', handler)
+        return () => {
+            window.removeEventListener('keydown', handler)
+        }
+    })
+}


### PR DESCRIPTION
This is a draft PR adding support for navigating cards using the arrow keys. This would improve the gameplay experience on devices with a keyboard.

The reason this is still WIP is that I'd like to aminate cards out of the screen, just like a normal swipe, even though users play with their keyboard.

## Ideas:

- Perhaps there could be a way to get `react-spring` to trigger a specific `to` annimation state.
- Otherwise, it could possibly be fixed using CSS transforms.

Resolves #11 
