### PR TITLE
feat: add support for dynamic player exposed parameters

### DIFF
--- a/public/data/default/stats.json
+++ b/public/data/default/stats.json
@@ -1,0 +1,22 @@
+[
+    {
+        "id": "environment",
+        "name": "Environment",
+        "icon": "GiWheat"
+    },
+    {
+        "id": "people",
+        "name": "People",
+        "icon": "IoIosPeople"
+    },
+    {
+        "id": "security",
+        "name": "Security",
+        "icon": "GiAk47"
+    },
+    {
+        "id": "money",
+        "name": "Money",
+        "icon": "GiMoneyStack"
+    }
+]

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -18,7 +18,10 @@ export default class Game extends Component {
         const card = this.addUniqueCardId(this.state.card)
         return (
             <>
-                <Stats stats={this.state.world.state} />
+                <Stats
+                    stats={this.state.world.state}
+                    params={this.props.worldData.gameParams}
+                />
                 <Deck
                     onSwipe={this.onSwipe.bind(this)}
                     card={card}

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -16,12 +16,15 @@ export default class Game extends Component {
 
     render() {
         const card = this.addUniqueCardId(this.state.card)
+        const worldState = this.state.world.state
+        const stats = this.props.worldData.stats.map(stat =>
+            Object.assign({}, stat, {
+                value: worldState[stat.id],
+            }),
+        )
         return (
             <>
-                <Stats
-                    stats={this.state.world.state}
-                    params={this.props.worldData.gameParams}
-                />
+                <Stats stats={stats} />
                 <Deck
                     onSwipe={this.onSwipe.bind(this)}
                     card={card}

--- a/src/components/Stats.js
+++ b/src/components/Stats.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components/macro'
-import { IoIosPeople } from 'react-icons/io'
-import { GiAk47, GiMoneyStack, GiWheat } from 'react-icons/gi'
+import * as IoIcons from 'react-icons/io'
+import * as GameIcons from 'react-icons/gi'
 
 import Bar from './Bar'
 
@@ -31,33 +31,20 @@ const Icon = styled.div`
     align-items: center;
 `
 
-function Stats({ stats }) {
+function Stats({ stats, params }) {
     return (
         <Container>
-            <Stat>
-                <Icon>
-                    <GiWheat size="80%" />
-                </Icon>
-                <Bar value={stats.environment} />
-            </Stat>
-            <Stat>
-                <Icon>
-                    <IoIosPeople size="80%" />
-                </Icon>
-                <Bar value={stats.people} />
-            </Stat>
-            <Stat>
-                <Icon>
-                    <GiAk47 size="80%" />
-                </Icon>
-                <Bar value={stats.security} />
-            </Stat>
-            <Stat>
-                <Icon>
-                    <GiMoneyStack size="80%" />
-                </Icon>
-                <Bar value={stats.money} />
-            </Stat>
+            {params.map(p => {
+                const IconWidget = GameIcons[p.icon] || IoIcons[p.icon]
+                return (
+                    <Stat key={p.id}>
+                        <Icon>
+                            <IconWidget size="80%" />
+                        </Icon>
+                        <Bar value={stats[p.id]} />
+                    </Stat>
+                )
+            })}
         </Container>
     )
 }

--- a/src/components/Stats.js
+++ b/src/components/Stats.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import styled from 'styled-components/macro'
+
+// This could prove to be a hit in binary size since we require all the icons in each pack. This compromise allows for more dynamic content.
 import * as IoIcons from 'react-icons/io'
 import * as GameIcons from 'react-icons/gi'
+import * as FontAwesomeIcons from 'react-icons/fa'
 
 import Bar from './Bar'
 
@@ -31,17 +34,22 @@ const Icon = styled.div`
     align-items: center;
 `
 
-function Stats({ stats, params }) {
+function Stats({ stats }) {
     return (
         <Container>
-            {params.map(p => {
-                const IconWidget = GameIcons[p.icon] || IoIcons[p.icon]
+            {stats.map(s => {
+                const IconWidget =
+                    GameIcons[s.icon] ||
+                    IoIcons[s.icon] ||
+                    FontAwesomeIcons[s.icon]
+                const iconSize = s.iconSize || '80%'
+                const value = s.value
                 return (
-                    <Stat key={p.id}>
+                    <Stat key={s.id}>
                         <Icon>
-                            <IconWidget size="80%" />
+                            {IconWidget && <IconWidget size={iconSize} />}
                         </Icon>
-                        <Bar value={stats[p.id]} />
+                        <Bar value={value} />
                     </Stat>
                 )
             })}

--- a/src/game/GameWorld.js
+++ b/src/game/GameWorld.js
@@ -16,7 +16,31 @@ export const DEFAULT_GAME_STATE = Object.freeze({
     flags: {},
 })
 
+const defaultGameParams = [
+    {
+        id: 'environment',
+        name: 'Environment',
+        icon: 'GiWheat',
+    },
+    {
+        id: 'people',
+        name: 'People',
+        icon: 'IoIosPeople',
+    },
+    {
+        id: 'security',
+        name: 'Security',
+        icon: 'GiAk47',
+    },
+    {
+        id: 'money',
+        name: 'Money',
+        icon: 'GiMoneyStack',
+    },
+]
+
 export const defaultGameWorld = {
+    gameParams: defaultGameParams,
     cards: defaultCards,
     events: defaultEvents,
     eventCards: defaultEventCards,
@@ -38,10 +62,13 @@ async function tryLoadFromLocalStorage(path) {
         let gameWorld = {}
         try {
             const data = JSON.parse(localStorage.getItem(gameWorldId))
-            if (!data) throw new Error("Could not load data from local storage: " + gameWorldId);
+            if (!data)
+                throw new Error(
+                    'Could not load data from local storage: ' + gameWorldId,
+                )
             gameWorld = data || {}
         } catch (e) {
-            console.log(e);
+            console.log(e)
         }
         return Object.assign({}, defaultGameWorld, gameWorld)
     }
@@ -67,21 +94,21 @@ async function tryLoadFromInternalData(path) {
 
 async function tryLoadFromRestAPI(path) {
     // Default: expect a folder to represent a game world and contain specific JSON-files.
+    const paramsPath = path + '/params.json'
     const cardsPath = path + '/cards.json'
     const eventsPath = path + '/events.json'
     const eventCardsPath = path + '/event-cards.json'
     const defaultStatePath = path + '/default-state.json'
 
     // IDEA: load data in parallel instead of sequentially to improve performance
+    const gameParams = await fetchJSON(paramsPath, defaultGameParams)
     const cards = await fetchJSON(cardsPath, [])
     const events = await fetchJSON(eventsPath, [])
     const eventCards = await fetchJSON(eventCardsPath, {})
-    const defaultState = await fetchJSON(
-        defaultStatePath,
-        DEFAULT_GAME_STATE,
-    )
+    const defaultState = await fetchJSON(defaultStatePath, DEFAULT_GAME_STATE)
 
     return {
+        gameParams,
         cards,
         events,
         eventCards,
@@ -90,7 +117,11 @@ async function tryLoadFromRestAPI(path) {
 }
 
 export async function loadGameWorld(path) {
-    return (await tryLoadFromInternalData(path)) || (await tryLoadFromLocalStorage(path)) || (await tryLoadFromRestAPI(path))
+    return (
+        (await tryLoadFromInternalData(path)) ||
+        (await tryLoadFromLocalStorage(path)) ||
+        (await tryLoadFromRestAPI(path))
+    )
 }
 
 async function fetchJSON(path, defaultValue) {

--- a/src/game/GameWorld.js
+++ b/src/game/GameWorld.js
@@ -16,7 +16,7 @@ export const DEFAULT_GAME_STATE = Object.freeze({
     flags: {},
 })
 
-const defaultGameParams = [
+const defaultStats = [
     {
         id: 'environment',
         name: 'Environment',
@@ -40,7 +40,7 @@ const defaultGameParams = [
 ]
 
 export const defaultGameWorld = {
-    gameParams: defaultGameParams,
+    stats: defaultStats,
     cards: defaultCards,
     events: defaultEvents,
     eventCards: defaultEventCards,
@@ -76,6 +76,7 @@ async function tryLoadFromLocalStorage(path) {
     return null
 }
 
+// Load GameWorld from data directory of this repository
 async function tryLoadFromInternalData(path) {
     const matchInternal = path.match(/^internal:\/\/(.*)/)
 
@@ -94,21 +95,21 @@ async function tryLoadFromInternalData(path) {
 
 async function tryLoadFromRestAPI(path) {
     // Default: expect a folder to represent a game world and contain specific JSON-files.
-    const paramsPath = path + '/params.json'
+    const statsPath = path + '/stats.json'
     const cardsPath = path + '/cards.json'
     const eventsPath = path + '/events.json'
     const eventCardsPath = path + '/event-cards.json'
     const defaultStatePath = path + '/default-state.json'
 
     // IDEA: load data in parallel instead of sequentially to improve performance
-    const gameParams = await fetchJSON(paramsPath, defaultGameParams)
+    const stats = await fetchJSON(statsPath, defaultStats)
     const cards = await fetchJSON(cardsPath, [])
     const events = await fetchJSON(eventsPath, [])
     const eventCards = await fetchJSON(eventCardsPath, {})
     const defaultState = await fetchJSON(defaultStatePath, DEFAULT_GAME_STATE)
 
     return {
-        gameParams,
+        stats,
         cards,
         events,
         eventCards,


### PR DESCRIPTION
This PR will add support enable dynamically specifying the parameters which are exposed to the player. This removes the need to recompile the application in order to support extended or experimental parameter sets. Should be useful moving forward with the design of the game.

Notice: `import * as IoIcons from 'react-icons/io'` in `Stats.js` this could prove to be a hit in binary size since we require all the icons in each pack. I am fine with this compromise in order to allow for more dynamic content.