### PR TITLE
fix(loading perf): Improve loading performance by using parallel data loading

### DIFF
--- a/src/game/GameWorld.ts
+++ b/src/game/GameWorld.ts
@@ -113,8 +113,6 @@ async function tryLoadFromRestAPI(path: string): Promise<GameWorld | null> {
     const eventCardsPath = path + '/event-cards.json'
     const defaultStatePath = path + '/default-state.json'
 
-    // IDEA: load data in parallel instead of sequentially to improve performance
-    // Use Promise.all() or similar - https://stackoverflow.com/a/35612484
     const [stats, cards, events, eventCards, defaultState] = await Promise.all<
         StatDefinition[],
         CardData[],
@@ -122,11 +120,11 @@ async function tryLoadFromRestAPI(path: string): Promise<GameWorld | null> {
         EventCards,
         WorldState
     >([
-        await fetchJSON(statsPath, defaultStats),
-        await fetchJSON(cardsPath, []),
-        await fetchJSON(eventsPath, []),
-        await fetchJSON(eventCardsPath, {}),
-        await fetchJSON(defaultStatePath, DEFAULT_GAME_STATE),
+        fetchJSON(statsPath, defaultStats),
+        fetchJSON(cardsPath, []),
+        fetchJSON(eventsPath, []),
+        fetchJSON(eventCardsPath, {}),
+        fetchJSON(defaultStatePath, DEFAULT_GAME_STATE),
     ])
 
     return {


### PR DESCRIPTION
We implemented the `Promise.all()` call but forgot to remove the individual await expressions for the individual promises. This effectively removed any benefits we might have seen, and added extra overhead instead.

Note that the following was measured by diffing`performance.now()` in a local environment. Using parallel loading in a real environment should make an even greater difference.

Before this PR:

![Screenshot 2020-06-03 at 08 09 33](https://user-images.githubusercontent.com/6125097/83602123-40308d80-a572-11ea-8b32-2153109f4402.png)

After this PR:
![Screenshot 2020-06-03 at 08 10 41](https://user-images.githubusercontent.com/6125097/83602126-4161ba80-a572-11ea-83a0-e3791128222c.png)
