### PR TITLE
Feature/refactor game component to separate module

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import styled from 'styled-components/macro'
 
 import Game from './components/Game'
-import { loadGameWorld } from './game/GameWorld'
+import { loadScenario } from './game/load-scenario'
 import { GameWorld } from './game/ContentTypes'
 
 const Container = styled.main`
@@ -20,15 +20,15 @@ type AppProps = {
 }
 
 function App({ path }: AppProps) {
-    const [worldData, setWorldData] = useState<GameWorld | null>(null)
+    const [scenario, setScenario] = useState<GameWorld | null>(null)
     useEffect(() => {
         const fetchWorld = async () => {
-            const worldData = await loadGameWorld(path)
-            setWorldData(worldData)
+            const scenario = await loadScenario(path)
+            setScenario(scenario)
         }
         fetchWorld()
-    }, [path, setWorldData])
-    return <Container>{worldData && <Game worldData={worldData} />}</Container>
+    }, [path, setScenario])
+    return <Container>{scenario && <Game scenario={scenario} />}</Container>
 }
 
 export default App

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from 'react'
 import styled from 'styled-components/macro'
 
 import Game from './components/Game'
+import { GameScenario, BasicGameScenario } from './game/GameScenario'
 import { loadScenario } from './game/load-scenario'
-import { GameWorld } from './game/ContentTypes'
 
 const Container = styled.main`
     position: absolute;
@@ -20,11 +20,16 @@ type AppProps = {
 }
 
 function App({ path }: AppProps) {
-    const [scenario, setScenario] = useState<GameWorld | null>(null)
+    const [scenario, setScenario] = useState<GameScenario | null>(null)
     useEffect(() => {
         const fetchWorld = async () => {
-            const scenario = await loadScenario(path)
-            setScenario(scenario)
+            const scenarioData = await loadScenario(path)
+            if (scenarioData) {
+                const instance = new BasicGameScenario(scenarioData)
+                setScenario(instance)
+            } else {
+                console.warn('Scenario loading error')
+            }
         }
         fetchWorld()
     }, [path, setScenario])

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -35,7 +35,12 @@ const Game: React.FunctionComponent<GameProps> = ({ scenario }) => {
         card: CardData | EventCard,
         direction: SwipeDirection,
     ): void {
-        setState(getUpdatedState(scenario, state, card, direction))
+        const action =
+            direction === SwipeDirection.Left
+                ? card.actions.left
+                : card.actions.right
+
+        setState(getUpdatedState(scenario, state, card, action))
     }
 
     return (

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -6,6 +6,7 @@ import Stats from './Stats'
 import { SwipeDirection } from '../util/constants'
 import { getInitialState, getUpdatedState } from '../game/GameScenario'
 import { GameWorld, CardData, EventCard } from '../game/ContentTypes'
+import { GameState } from '../game/GameTypes'
 
 const Footer = styled.footer`
     display: flex;
@@ -16,15 +17,15 @@ const Footer = styled.footer`
 // IDEA: Rename `worldData` to `scenario` to clarify the purpose of this data.
 // It would make it easier to understand how game scenarios simply define the default data, while `GameState` is used during runtime.
 type GameProps = {
-    worldData: GameWorld
+    scenario: GameWorld
 }
 
-const Game: React.FunctionComponent<GameProps> = ({ worldData }) => {
-    const [state, setState] = useState(getInitialState(worldData))
+const Game: React.FunctionComponent<GameProps> = ({ scenario }) => {
+    const [state, setState] = useState<GameState>(getInitialState(scenario))
 
     const card = addUniqueCardId(state.card)
     const worldState = state.world.state
-    const stats = worldData.stats.map((stat) =>
+    const stats = scenario.stats.map((stat) =>
         Object.assign({}, stat, {
             value: worldState[stat.id],
         }),
@@ -34,7 +35,7 @@ const Game: React.FunctionComponent<GameProps> = ({ worldData }) => {
         card: CardData | EventCard,
         direction: SwipeDirection,
     ): void {
-        setState(getUpdatedState(worldData, state, card, direction))
+        setState(getUpdatedState(scenario, state, card, direction))
     }
 
     return (

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components/macro'
 import Deck from './Deck'
 import Stats from './Stats'
 import { SwipeDirection } from '../util/constants'
-import { getInitialState, getUpdatedState } from '../game/GameScenario'
-import { GameWorld, CardData, EventCard } from '../game/ContentTypes'
+import { GameScenario } from '../game/GameScenario'
+import { CardData, EventCard } from '../game/ContentTypes'
 import { GameState } from '../game/GameTypes'
 
 const Footer = styled.footer`
@@ -14,14 +14,12 @@ const Footer = styled.footer`
     align-items: center;
 `
 
-// IDEA: Rename `worldData` to `scenario` to clarify the purpose of this data.
-// It would make it easier to understand how game scenarios simply define the default data, while `GameState` is used during runtime.
 type GameProps = {
-    scenario: GameWorld
+    scenario: GameScenario
 }
 
 const Game: React.FunctionComponent<GameProps> = ({ scenario }) => {
-    const [state, setState] = useState<GameState>(getInitialState(scenario))
+    const [state, setState] = useState<GameState>(scenario.getInitialState())
 
     const card = addUniqueCardId(state.card)
     const worldState = state.world.state
@@ -40,7 +38,7 @@ const Game: React.FunctionComponent<GameProps> = ({ scenario }) => {
                 ? card.actions.left
                 : card.actions.right
 
-        setState(getUpdatedState(scenario, state, card, action))
+        setState(scenario.getUpdatedState(state, card, action))
     }
 
     return (

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -4,18 +4,14 @@ import styled from 'styled-components/macro'
 import Deck from './Deck'
 import Stats from './Stats'
 import { SwipeDirection } from '../util/constants'
+import GameScenario from '../game/GameScenario'
 
 import {
     GameWorld,
     WorldState,
-    WorldQuery,
-    GameWorldModifier,
-    WorldEvent,
     CardData,
     EventCard,
-    CardActionData,
-    EventCardActionData,
-    EventCardId,
+    WorldEvent,
 } from '../game/ContentTypes'
 
 const Footer = styled.footer`
@@ -51,7 +47,10 @@ window.DEV_TOOLS_ACTIVE = window.location.hostname.includes('localhost')
 window.DEV_TOOLS = {}
 
 export default class Game extends Component<GameProps, GameState> {
-    state = this.getInitialState()
+    constructor() {
+        this.scenario = new GameScenario(this.props.worldData)
+        this.state = this.scenario.getInitialState()
+    }
 
     render() {
         const card = this.addUniqueCardId(this.state.card)
@@ -76,67 +75,8 @@ export default class Game extends Component<GameProps, GameState> {
         )
     }
 
-    getInitialState() {
-        const defaultState = this.props.worldData.defaultState
-        return {
-            world: defaultState,
-            card: this.getInitialCard(defaultState),
-            rounds: 0,
-        }
-    }
-
-    getInitialCard(world: WorldState): EventCard | CardData {
-        const availableEvents = this.getAvailableEvents(world)
-        const event = this.selectNextEvent(availableEvents)
-
-        if (event) {
-            return this.selectEventCard(event.initialEventCardId)
-        } else {
-            return this.selectNextCard(
-                this.getAvailableCards(this.props.worldData.defaultState),
-            )
-        }
-    }
-
-    getAvailableCards(world: WorldState): CardData[] {
-        const { cards } = this.props.worldData
-        return cards.filter((c) =>
-            this.hasMatchingWorldQuery(world, c.isAvailableWhen),
-        )
-    }
-
-    getAvailableEvents(world: WorldState): WorldEvent[] {
-        const { events } = this.props.worldData
-        return events.filter((e) =>
-            this.hasMatchingWorldQuery(world, e.isAvailableWhen),
-        )
-    }
-
-    hasMatchingWorldQuery(
-        world: WorldState,
-        worldQueries: WorldQuery[],
-    ): Boolean {
-        return worldQueries.some((q) => this.isMatchingWorldQuery(world, q))
-    }
-
-    isMatchingWorldQuery(
-        world: WorldState,
-        { state = {}, flags = {} }: WorldQuery,
-    ): Boolean {
-        const hasStateMatch = Object.entries(state).every(
-            ([key, [min, max]]) =>
-                world.state[key] >= min && world.state[key] <= max,
-        )
-
-        const result =
-            hasStateMatch &&
-            Object.entries(flags).every(
-                ([flag, value]) => world.flags[flag] === value,
-            )
-
-        return result
-    }
-
+    // TODO: Handle the game state update on each swipe.
+    // Call some kind of update method in the game scenario and store the result in
     onSwipe(card: CardData | EventCard, direction: SwipeDirection): void {
         const currentAction =
             direction === SwipeDirection.Left
@@ -150,173 +90,5 @@ export default class Game extends Component<GameProps, GameState> {
             card: this.getNextCard(updatedWorld, card, currentAction),
             rounds: this.state.rounds + 1,
         })
-    }
-
-    getNextCard(
-        updatedWorld: WorldState,
-        card: CardData | EventCard,
-        currentAction: CardActionData | EventCardActionData,
-    ): CardData | EventCard {
-        const { eventCards } = this.props.worldData
-        const availableEvents = this.getAvailableEvents(updatedWorld)
-        let availableCards: CardData[] = []
-
-        const nextEventCardId: string | null =
-            card.type === 'event' && 'nextEventCardId' in currentAction
-                ? currentAction.nextEventCardId
-                : null
-        const eventStartingNow = !nextEventCardId
-            ? this.selectNextEvent(availableEvents)
-            : null
-        let nextCard
-
-        // Only select the next EventCard if a specific one is given
-        // Else cancel the event and continue with normal cards.
-        if (nextEventCardId) {
-            if (!eventCards.hasOwnProperty(nextEventCardId)) {
-                throw new Error(
-                    `eventCardId "${nextEventCardId}" does not exist. Make sure it's spelled correctly`,
-                )
-            }
-            nextCard = this.selectEventCard(nextEventCardId)
-        } else if (eventStartingNow) {
-            nextCard = this.selectEventCard(eventStartingNow.initialEventCardId)
-        } else {
-            availableCards = this.getAvailableCards(updatedWorld)
-            nextCard = this.selectNextCard(availableCards)
-        }
-
-        if (window.DEV_TOOLS_ACTIVE) {
-            window.DEV_TOOLS.game = {
-                world: this.state.world,
-                rounds: this.state.rounds,
-                card: this.state.card,
-            }
-
-            window.DEV_TOOLS.availableCards = availableCards
-            window.DEV_TOOLS.availableEvents = availableEvents
-
-            console.log('DEV TOOLS: ', window.DEV_TOOLS)
-        }
-
-        if (!nextCard) throw new Error('Content error. No next card available.')
-        return nextCard
-    }
-
-    getUpdatedWorld({
-        type = 'add',
-        state = {},
-        flags = {},
-    }: GameWorldModifier): WorldState {
-        // get default values for missing props by destructuring the incoming `modifier` and then directly reassembling it
-        // IDEA: Could this all be done in the function declaration, when specifying parameters?
-        const modifier: GameWorldModifier = { type, state, flags }
-        const updatedWorldState = this.updateWorldState(modifier)
-        const updatedWorldFlags = this.updateWorldFlags(modifier)
-
-        return {
-            state: updatedWorldState,
-            flags: updatedWorldFlags,
-        }
-    }
-
-    updateWorldState(modifier: GameWorldModifier): WorldState['state'] {
-        const currentWorldState: WorldState['state'] =
-            modifier.type === 'replace'
-                ? Object.assign({}, this.props.worldData.defaultState.state)
-                : Object.assign({}, this.state.world.state)
-
-        const stateModifier = modifier.state || {}
-        const updatedWorldState = Object.entries(stateModifier).reduce<
-            WorldState['state']
-        >((updatedState: WorldState['state'], [key, value]) => {
-            const newValue =
-                modifier.type === 'set' || modifier.type === 'replace'
-                    ? value
-                    : value + (updatedState[key] || 0)
-
-            updatedState[key] = Math.min(Math.max(newValue, 0), 100)
-
-            return updatedState
-        }, currentWorldState)
-
-        return updatedWorldState
-    }
-
-    updateWorldFlags(modifier: GameWorldModifier): WorldState['flags'] {
-        const currentWorldFlags: WorldState['flags'] =
-            modifier.type === 'replace'
-                ? Object.assign({}, this.props.worldData.defaultState.flags)
-                : Object.assign({}, this.state.world.flags)
-
-        const flagsModifier = modifier.flags || {}
-        const updatedWorldFlags = Object.entries(flagsModifier).reduce<
-            WorldState['flags']
-        >((updatedFlags, [key, value]) => {
-            updatedFlags[key] = value
-            return updatedFlags
-        }, currentWorldFlags)
-
-        return updatedWorldFlags
-    }
-
-    addUniqueCardId(
-        card: CardData | EventCard,
-        index: number = 0,
-    ): (CardData | EventCard) & { id: string } {
-        return {
-            ...card,
-            id: Date.now() + ':' + index,
-        }
-    }
-
-    selectNextCard(cards: CardData[] = []): CardData {
-        return this.selectWeightedRandomFrom(cards)
-    }
-
-    selectNextEvent(events: WorldEvent[] = []): WorldEvent | undefined {
-        const event = this.selectRandomFrom(events)
-        if (event && Math.random() <= event.probability) {
-            return event
-        }
-    }
-
-    selectRandomFrom<T>(array: T[]): T {
-        return array[Math.floor(Math.random() * array.length)]
-    }
-
-    selectWeightedRandomFrom<T extends { weight: number }>(
-        array: T[],
-        weightFunc = (element: T) => element.weight,
-    ): T {
-        const { selectionList, count } = array.reduce<{
-            count: number
-            selectionList: number[]
-        }>(
-            (acc, element) => {
-                acc.count += weightFunc(element)
-                acc.selectionList.push(acc.count)
-                return acc
-            },
-            { count: 0, selectionList: [] },
-        )
-
-        const selectionPosition = Math.random() * count
-        const selectionIndex = selectionList.findIndex((max, index, array) => {
-            const min = index > 0 ? array[index - 1] : 0
-            return selectionPosition >= min && selectionPosition <= max
-        })
-
-        return array[selectionIndex]
-    }
-
-    selectEventCard(cardId: EventCardId): EventCard {
-        const { eventCards } = this.props.worldData
-        const eventCard = eventCards[cardId]
-        if (!eventCard)
-            throw new Error(
-                `ContentError: EventCard with EventCardId "${cardId}" does not exist`,
-            )
-        return eventCard
     }
 }

--- a/src/game/ContentTypes.ts
+++ b/src/game/ContentTypes.ts
@@ -1,3 +1,5 @@
+// ContentTypes are used to describe the format and structure for game scenarios and content.
+
 export type GameWorld = {
     stats: StatDefinition[]
     cards: CardData[]

--- a/src/game/GameScenario.ts
+++ b/src/game/GameScenario.ts
@@ -12,299 +12,279 @@ import {
     EventCardId,
 } from './ContentTypes'
 
-// TODO: break out dev tools and global state from this module, so the Game component itself handles that based on state
-// The new functional approach with this module will allow us to get deeper insights into how the game runs.
-// This hopefully should make it easier to separate dev tools from the GameScenario module.
-
-// declare global {
-//     interface Window {
-//         DEV_TOOLS_ACTIVE: Boolean
-//         DEV_TOOLS: {
-//             availableCards?: CardData[]
-//             availableEvents?: WorldEvent[]
-//             nextCard?: CardData | EventCard
-//             game?: GameState
-//         }
-//     }
-// }
-
-// // Enable DEV_TOOLS for local development by default to improve DX
-// window.DEV_TOOLS_ACTIVE = window.location.hostname.includes('localhost')
-// window.DEV_TOOLS = {}
-
-// IDEA: Use Scenario type instead of GameWorld, to add full context with the Scenario ID too.
-// Could make debugging easier since the scenario could know it's ID.
-// Porentially, this could also allow us to remove the GameWorld Type and replace it with Scenario, which is much easier to understand.
-
-// IDEA: Refactor into a set of pure functions that take can simulate a scenario deterministically. Maybe not use a class, but rather a set of functions
-// IDEA: Replace Math.random() usage and require all user code to pass in the random selection function, to ensure this module is deterministic.
-// IDEA: By keeping the GameScenario stateless, it will be easy to use both in game and in tests.
-// IDEA: Stateless It could also allow other uses, like training an AI to find the optimal endgame conditions, and the strategies used to get there.
-
-// IDEA: Ensure functions are pure by making copies of objects instead of passing by reference.
-//       This is especially important when using the default data `scenario` which shouldn't be mutated.
-
-/**
- * Get the initial state for a given scenario.
- *
- * @param scenario The scenario default data which holds all cards, events and similar
- */
-export function getInitialState(scenario: GameWorld): GameState {
-    return {
-        world: scenario.defaultState,
-        card: getInitialCard(scenario),
-        rounds: 0,
-    }
+export interface GameScenario {
+    getInitialState(): GameState
+    getUpdatedState(
+        prevState: GameState,
+        card: CardData | EventCard,
+        action: CardActionData | EventCardActionData,
+    ): GameState
+    stats: GameWorld['stats']
 }
 
 /**
- * Get the updated state for a scenario based on previous state and the action taken to move forward.
+ * BasicGameScenario used to simulate game scenarios.
  *
- * Since all dependencies are clearly stated throughout all child functions,
- * it's really easy to change partial data and state to get a different updated state.
- * This could be really useful for testing, or perhaps even some kind of AI to find the optimal actions/strategy
- *
- * @param scenario The scenario default data which holds all cards, events and similar
- * @param prevState The state before this update
- * @param card The currently visible card that the player is acting upon
- * @param action The player's choosen action for how to move forward in the game
+ * The design goal is to keep this stateless, allowing user code to manage state.
  */
-export function getUpdatedState(
-    scenario: GameWorld,
-    prevState: GameState,
-    card: CardData | EventCard,
-    action: CardActionData | EventCardActionData,
-): GameState {
-    const updatedWorld = getUpdatedWorld(
-        scenario,
-        action.modifier,
-        prevState.world,
-    )
+export class BasicGameScenario implements GameScenario {
+    protected _scenario: GameWorld
+    protected _random: () => number
 
-    return {
-        world: updatedWorld,
-        card: getNextCard(scenario, updatedWorld, card, action),
-        rounds: prevState.rounds + 1,
+    constructor(scenario: GameWorld, random: () => number = Math.random) {
+        this._scenario = scenario
+        this._random = random
     }
-}
 
-function getUpdatedWorld(
-    scenario: GameWorld,
-    { type = 'add', state = {}, flags = {} }: GameWorldModifier,
-    world: WorldState,
-): WorldState {
-    // get default values for missing props by destructuring the incoming `modifier` and then directly reassembling it
-    // IDEA: Could this all be done in the function declaration, when specifying parameters?
-    const modifier: GameWorldModifier = { type, state, flags }
-    const updatedWorldState = updateWorldState(scenario, modifier, world)
-    const updatedWorldFlags = updateWorldFlags(scenario, modifier, world)
-
-    return {
-        state: updatedWorldState,
-        flags: updatedWorldFlags,
+    get stats() {
+        return this._scenario.stats
     }
-}
 
-function updateWorldState(
-    scenario: GameWorld,
-    modifier: GameWorldModifier,
-    world: WorldState,
-): WorldState['state'] {
-    const currentWorldState: WorldState['state'] =
-        modifier.type === 'replace'
-            ? Object.assign({}, scenario.defaultState.state)
-            : Object.assign({}, world.state)
+    /**
+     * Get the initial state for a given scenario.
+     *
+     * @param scenario The scenario default data which holds all cards, events and similar
+     */
+    getInitialState(): GameState {
+        return {
+            world: this._scenario.defaultState,
+            card: this.getInitialCard(),
+            rounds: 0,
+        }
+    }
 
-    const stateModifier = modifier.state || {}
-    const updatedWorldState = Object.entries(stateModifier).reduce<
-        WorldState['state']
-    >((updatedState: WorldState['state'], [key, value]) => {
-        const newValue =
-            modifier.type === 'set' || modifier.type === 'replace'
-                ? value
-                : value + (updatedState[key] || 0)
-
-        updatedState[key] = Math.min(Math.max(newValue, 0), 100)
-
-        return updatedState
-    }, currentWorldState)
-
-    return updatedWorldState
-}
-
-function updateWorldFlags(
-    scenario: GameWorld,
-    modifier: GameWorldModifier,
-    world: WorldState,
-): WorldState['flags'] {
-    const currentWorldFlags: WorldState['flags'] =
-        modifier.type === 'replace'
-            ? Object.assign({}, scenario.defaultState.flags)
-            : Object.assign({}, world.flags)
-
-    const flagsModifier = modifier.flags || {}
-    const updatedWorldFlags = Object.entries(flagsModifier).reduce<
-        WorldState['flags']
-    >((updatedFlags, [key, value]) => {
-        updatedFlags[key] = value
-        return updatedFlags
-    }, currentWorldFlags)
-
-    return updatedWorldFlags
-}
-
-function getInitialCard(scenario: GameWorld): EventCard | CardData {
-    const availableEvents = getAvailableEvents(scenario, scenario.defaultState)
-    const event = selectNextEvent(availableEvents)
-
-    if (event) {
-        return selectEventCard(scenario, event.initialEventCardId)
-    } else {
-        return selectNextCard(
-            getAvailableCards(scenario, scenario.defaultState),
+    /**
+     * Get the updated state for a scenario based on previous state and the action taken to move forward.
+     *
+     * Since all dependencies are clearly stated throughout all child functions,
+     * it's really easy to change partial data and state to get a different updated state.
+     * This could be really useful for testing, or perhaps even some kind of AI to find the optimal actions/strategy
+     *
+     * @param scenario The scenario default data which holds all cards, events and similar
+     * @param prevState The state before this update
+     * @param card The currently visible card that the player is acting upon
+     * @param action The player's choosen action for how to move forward in the game
+     */
+    getUpdatedState(
+        prevState: GameState,
+        card: CardData | EventCard,
+        action: CardActionData | EventCardActionData,
+    ): GameState {
+        const updatedWorld = this.getUpdatedWorld(
+            action.modifier,
+            prevState.world,
         )
+
+        return {
+            world: updatedWorld,
+            card: this.getNextCard(updatedWorld, card, action),
+            rounds: prevState.rounds + 1,
+        }
     }
-}
 
-function getNextCard(
-    scenario: GameWorld,
-    updatedWorld: WorldState,
-    card: CardData | EventCard,
-    action: CardActionData | EventCardActionData,
-): CardData | EventCard {
-    const { eventCards } = scenario
-    const availableEvents = getAvailableEvents(scenario, updatedWorld)
-    let availableCards: CardData[] = []
+    getUpdatedWorld(
+        inputModifier: GameWorldModifier,
+        world: WorldState,
+    ): WorldState {
+        const modifier: GameWorldModifier = {
+            type: 'add',
+            state: {},
+            flags: {},
+            ...inputModifier,
+        }
+        const updatedWorldState = this.updateWorldState(modifier, world)
+        const updatedWorldFlags = this.updateWorldFlags(modifier, world)
 
-    const nextEventCardId: string | null =
-        card.type === 'event' && 'nextEventCardId' in action
-            ? action.nextEventCardId
-            : null
-    const eventStartingNow = !nextEventCardId
-        ? selectNextEvent(availableEvents)
-        : null
-    let nextCard
+        return {
+            state: updatedWorldState,
+            flags: updatedWorldFlags,
+        }
+    }
 
-    // Only select the next EventCard if a specific one is given
-    // Else cancel the event and continue with normal cards.
-    if (nextEventCardId) {
-        if (!eventCards.hasOwnProperty(nextEventCardId)) {
-            throw new Error(
-                `eventCardId "${nextEventCardId}" does not exist. Make sure it's spelled correctly`,
+    updateWorldState(
+        modifier: GameWorldModifier,
+        world: WorldState,
+    ): WorldState['state'] {
+        const currentWorldState: WorldState['state'] =
+            modifier.type === 'replace'
+                ? Object.assign({}, this._scenario.defaultState.state)
+                : Object.assign({}, world.state)
+
+        const stateModifier = modifier.state || {}
+        const updatedWorldState = Object.entries(stateModifier).reduce<
+            WorldState['state']
+        >((updatedState: WorldState['state'], [key, value]) => {
+            const newValue =
+                modifier.type === 'set' || modifier.type === 'replace'
+                    ? value
+                    : value + (updatedState[key] || 0)
+
+            updatedState[key] = Math.min(Math.max(newValue, 0), 100)
+
+            return updatedState
+        }, currentWorldState)
+
+        return updatedWorldState
+    }
+
+    updateWorldFlags(
+        modifier: GameWorldModifier,
+        world: WorldState,
+    ): WorldState['flags'] {
+        const currentWorldFlags: WorldState['flags'] =
+            modifier.type === 'replace'
+                ? Object.assign({}, this._scenario.defaultState.flags)
+                : Object.assign({}, world.flags)
+
+        const flagsModifier = modifier.flags || {}
+        const updatedWorldFlags = Object.entries(flagsModifier).reduce<
+            WorldState['flags']
+        >((updatedFlags, [key, value]) => {
+            updatedFlags[key] = value
+            return updatedFlags
+        }, currentWorldFlags)
+
+        return updatedWorldFlags
+    }
+
+    getInitialCard(): EventCard | CardData {
+        const availableEvents = this.getAvailableEvents(
+            this._scenario.defaultState,
+        )
+        const event = this.selectNextEvent(availableEvents)
+
+        if (event) {
+            return this.selectEventCard(event.initialEventCardId)
+        } else {
+            return this.selectNextCard(
+                this.getAvailableCards(this._scenario.defaultState),
             )
         }
-        nextCard = selectEventCard(scenario, nextEventCardId)
-    } else if (eventStartingNow) {
-        nextCard = selectEventCard(
-            scenario,
-            eventStartingNow.initialEventCardId,
-        )
-    } else {
-        availableCards = getAvailableCards(scenario, updatedWorld)
-        nextCard = selectNextCard(availableCards)
     }
 
-    // TODO: break out dev tools from this module and add it to the Game Component instead. See comments up top for details.
-    // if (window.DEV_TOOLS_ACTIVE) {
-    //     window.DEV_TOOLS.game = {
-    //         world: this.state.world,
-    //         rounds: this.state.rounds,
-    //         card: this.state.card,
-    //     }
+    getNextCard(
+        updatedWorld: WorldState,
+        card: CardData | EventCard,
+        action: CardActionData | EventCardActionData,
+    ): CardData | EventCard {
+        const { eventCards } = this._scenario
+        const availableEvents = this.getAvailableEvents(updatedWorld)
+        let availableCards: CardData[] = []
 
-    //     window.DEV_TOOLS.availableCards = availableCards
-    //     window.DEV_TOOLS.availableEvents = availableEvents
+        const nextEventCardId: string | null =
+            card.type === 'event' && 'nextEventCardId' in action
+                ? action.nextEventCardId
+                : null
+        const eventStartingNow = !nextEventCardId
+            ? this.selectNextEvent(availableEvents)
+            : null
+        let nextCard
 
-    //     console.log('DEV TOOLS: ', window.DEV_TOOLS)
-    // }
+        // Only select the next EventCard if a specific one is given
+        // Else cancel the event and continue with normal cards.
+        if (nextEventCardId) {
+            if (!eventCards.hasOwnProperty(nextEventCardId)) {
+                throw new Error(
+                    `eventCardId "${nextEventCardId}" does not exist. Make sure it's spelled correctly`,
+                )
+            }
+            nextCard = this.selectEventCard(nextEventCardId)
+        } else if (eventStartingNow) {
+            nextCard = this.selectEventCard(eventStartingNow.initialEventCardId)
+        } else {
+            availableCards = this.getAvailableCards(updatedWorld)
+            nextCard = this.selectNextCard(availableCards)
+        }
 
-    if (!nextCard) throw new Error('Content error. No next card available.')
-    return nextCard
-}
-
-function getAvailableEvents(
-    scenario: GameWorld,
-    world: WorldState,
-): WorldEvent[] {
-    const { events } = scenario
-    return events.filter((e) => hasMatchingWorldQuery(world, e.isAvailableWhen))
-}
-
-function getAvailableCards(scenario: GameWorld, world: WorldState): CardData[] {
-    const { cards } = scenario
-    return cards.filter((c) => hasMatchingWorldQuery(world, c.isAvailableWhen))
-}
-
-function hasMatchingWorldQuery(
-    world: WorldState,
-    worldQueries: WorldQuery[],
-): Boolean {
-    return worldQueries.some((q) => isMatchingWorldQuery(world, q))
-}
-
-function isMatchingWorldQuery(
-    world: WorldState,
-    { state = {}, flags = {} }: WorldQuery,
-): Boolean {
-    const hasStateMatch = Object.entries(state).every(
-        ([key, [min, max]]) =>
-            world.state[key] >= min && world.state[key] <= max,
-    )
-
-    const result =
-        hasStateMatch &&
-        Object.entries(flags).every(
-            ([flag, value]) => world.flags[flag] === value,
-        )
-
-    return result
-}
-
-function selectNextEvent(events: WorldEvent[] = []): WorldEvent | undefined {
-    const event = selectRandomFrom(events)
-    if (event && Math.random() <= event.probability) {
-        return event
+        if (!nextCard) throw new Error('Content error. No next card available.')
+        return nextCard
     }
-}
 
-function selectEventCard(scenario: GameWorld, cardId: EventCardId): EventCard {
-    const eventCard = scenario.eventCards[cardId]
-    if (!eventCard)
-        throw new Error(
-            `ContentError: EventCard with EventCardId "${cardId}" does not exist`,
+    getAvailableEvents(world: WorldState): WorldEvent[] {
+        const { events } = this._scenario
+        return events.filter((e) =>
+            this.hasMatchingWorldQuery(world, e.isAvailableWhen),
         )
-    return eventCard
-}
+    }
 
-function selectRandomFrom<T>(array: T[]): T {
-    return array[Math.floor(Math.random() * array.length)]
-}
+    getAvailableCards(world: WorldState): CardData[] {
+        const { cards } = this._scenario
+        return cards.filter((c) =>
+            this.hasMatchingWorldQuery(world, c.isAvailableWhen),
+        )
+    }
 
-function selectNextCard(cards: CardData[] = []): CardData {
-    return selectWeightedRandomFrom(cards)
-}
+    hasMatchingWorldQuery(
+        world: WorldState,
+        worldQueries: WorldQuery[],
+    ): Boolean {
+        return worldQueries.some((q) => this.isMatchingWorldQuery(world, q))
+    }
 
-function selectWeightedRandomFrom<T extends { weight: number }>(
-    array: T[],
-    weightFunc = (element: T) => element.weight,
-): T {
-    const { selectionList, count } = array.reduce<{
-        count: number
-        selectionList: number[]
-    }>(
-        (acc, element) => {
-            acc.count += weightFunc(element)
-            acc.selectionList.push(acc.count)
-            return acc
-        },
-        { count: 0, selectionList: [] },
-    )
+    isMatchingWorldQuery(
+        world: WorldState,
+        { state = {}, flags = {} }: WorldQuery,
+    ): Boolean {
+        const hasStateMatch = Object.entries(state).every(
+            ([key, [min, max]]) =>
+                world.state[key] >= min && world.state[key] <= max,
+        )
 
-    const selectionPosition = Math.random() * count
-    const selectionIndex = selectionList.findIndex((max, index, array) => {
-        const min = index > 0 ? array[index - 1] : 0
-        return selectionPosition >= min && selectionPosition <= max
-    })
+        const result =
+            hasStateMatch &&
+            Object.entries(flags).every(
+                ([flag, value]) => world.flags[flag] === value,
+            )
 
-    return array[selectionIndex]
+        return result
+    }
+
+    selectNextEvent(events: WorldEvent[] = []): WorldEvent | undefined {
+        const event = this.selectRandomFrom(events)
+        if (event && this._random() <= event.probability) {
+            return event
+        }
+    }
+
+    selectEventCard(cardId: EventCardId): EventCard {
+        const eventCard = this._scenario.eventCards[cardId]
+        if (!eventCard)
+            throw new Error(
+                `ContentError: EventCard with EventCardId "${cardId}" does not exist`,
+            )
+        return eventCard
+    }
+
+    selectRandomFrom<T>(array: T[]): T {
+        return array[Math.floor(this._random() * array.length)]
+    }
+
+    selectNextCard(cards: CardData[] = []): CardData {
+        return this.selectWeightedRandomFrom(cards)
+    }
+
+    selectWeightedRandomFrom<T extends { weight: number }>(
+        array: T[],
+        weightFunc = (element: T) => element.weight,
+    ): T {
+        const { selectionList, count } = array.reduce<{
+            count: number
+            selectionList: number[]
+        }>(
+            (acc, element) => {
+                acc.count += weightFunc(element)
+                acc.selectionList.push(acc.count)
+                return acc
+            },
+            { count: 0, selectionList: [] },
+        )
+
+        const selectionPosition = this._random() * count
+        const selectionIndex = selectionList.findIndex((max, index, array) => {
+            const min = index > 0 ? array[index - 1] : 0
+            return selectionPosition >= min && selectionPosition <= max
+        })
+
+        return array[selectionIndex]
+    }
 }

--- a/src/game/GameScenario.ts
+++ b/src/game/GameScenario.ts
@@ -49,6 +49,22 @@ window.DEV_TOOLS = {}
 // IDEA: By keeping the GameScenario stateless, it will be easy to use both in game and in tests.
 // IDEA: Stateless It could also allow other uses, like training an AI to find the optimal endgame conditions, and the strategies used to get there.
 
+/* ----------------------- /*
+
+// IDEA: example usage for GameScenario
+import { getInitialState, getUpdatedState } from './GameScenario'
+
+// Raw data for current scenario
+const scenario: GameWorld = worldData
+
+// get initial state for the scenario
+let state = getInitialState(scenario)
+
+// Update state onSwipe. Then use new state however you want, either with setState() or directly in tests or similar.
+state = getUpdatedState(scenario, state, card, direction)
+
+/* ----------------------- */
+
 export default class GameScenario implements IGameScenario {
     scenario: GameWorld
     state: GameState

--- a/src/game/GameScenario.ts
+++ b/src/game/GameScenario.ts
@@ -43,6 +43,12 @@ declare global {
 window.DEV_TOOLS_ACTIVE = window.location.hostname.includes('localhost')
 window.DEV_TOOLS = {}
 
+// IDEA: Keep React state separate from actual scenario
+// IDEA: Refactor into a set of pure functions that take can simulate a scenario deterministically. Maybe not use a class, but rather a set of functions
+// IDEA: Replace Math.random() usage and require all user code to pass in the random selection function, to ensure this module is deterministic.
+// IDEA: By keeping the GameScenario stateless, it will be easy to use both in game and in tests.
+// IDEA: Stateless It could also allow other uses, like training an AI to find the optimal endgame conditions, and the strategies used to get there.
+
 export default class GameScenario implements IGameScenario {
     scenario: GameWorld
     state: GameState
@@ -50,29 +56,6 @@ export default class GameScenario implements IGameScenario {
     constructor(worldData: GameWorld) {
         this.scenario = worldData
         this.state = this.getInitialState()
-    }
-
-    render() {
-        const card = this.addUniqueCardId(this.state.card)
-        const worldState = this.state.world.state
-        const stats = this.scenario.stats.map((stat) =>
-            Object.assign({}, stat, {
-                value: worldState[stat.id],
-            }),
-        )
-        return (
-            <>
-                <Stats stats={stats} />
-                <Deck
-                    onSwipe={this.onSwipe.bind(this)}
-                    card={card}
-                    tick={this.state.rounds}
-                />
-                <Footer>
-                    <div className="time-remaining"></div>
-                </Footer>
-            </>
-        )
     }
 
     getInitialState(): GameState {
@@ -136,6 +119,7 @@ export default class GameScenario implements IGameScenario {
         return result
     }
 
+    // IDEA: Maybe replace this method if we want to go for an approach with pure functions rather than OOP.
     onSwipe(card: CardData | EventCard, direction: SwipeDirection): void {
         const currentAction =
             direction === SwipeDirection.Left

--- a/src/game/GameScenario.ts
+++ b/src/game/GameScenario.ts
@@ -1,0 +1,319 @@
+import { SwipeDirection } from '../util/constants'
+
+import {
+    GameWorld,
+    WorldState,
+    WorldQuery,
+    GameWorldModifier,
+    WorldEvent,
+    CardData,
+    EventCard,
+    CardActionData,
+    EventCardActionData,
+    EventCardId,
+} from '../game/ContentTypes'
+
+type GameState = {
+    world: WorldState
+    card: CardData | EventCard
+    rounds: number
+}
+
+interface IGameScenario {
+    // IDEA: Use Scenario type instead of GameWorld, to add full context with the Scenario ID too.
+    // Could make debugging easier since the scenario could know it's ID.
+    // Porentially, this could also allow us to remove the GameWorld Type and replace it with Scenario, which is much easier to understand.
+    scenario: GameWorld
+    state: GameState
+}
+
+declare global {
+    interface Window {
+        DEV_TOOLS_ACTIVE: Boolean
+        DEV_TOOLS: {
+            availableCards?: CardData[]
+            availableEvents?: WorldEvent[]
+            nextCard?: CardData | EventCard
+            game?: GameState
+        }
+    }
+}
+
+// Enable DEV_TOOLS for local development by default to improve DX
+window.DEV_TOOLS_ACTIVE = window.location.hostname.includes('localhost')
+window.DEV_TOOLS = {}
+
+export default class GameScenario implements IGameScenario {
+    scenario: GameWorld
+    state: GameState
+
+    constructor(worldData: GameWorld) {
+        this.scenario = worldData
+        this.state = this.getInitialState()
+    }
+
+    render() {
+        const card = this.addUniqueCardId(this.state.card)
+        const worldState = this.state.world.state
+        const stats = this.scenario.stats.map((stat) =>
+            Object.assign({}, stat, {
+                value: worldState[stat.id],
+            }),
+        )
+        return (
+            <>
+                <Stats stats={stats} />
+                <Deck
+                    onSwipe={this.onSwipe.bind(this)}
+                    card={card}
+                    tick={this.state.rounds}
+                />
+                <Footer>
+                    <div className="time-remaining"></div>
+                </Footer>
+            </>
+        )
+    }
+
+    getInitialState(): GameState {
+        const defaultState = this.scenario.defaultState
+        return {
+            world: defaultState,
+            card: this.getInitialCard(defaultState),
+            rounds: 0,
+        }
+    }
+
+    getInitialCard(world: WorldState): EventCard | CardData {
+        const availableEvents = this.getAvailableEvents(world)
+        const event = this.selectNextEvent(availableEvents)
+
+        if (event) {
+            return this.selectEventCard(event.initialEventCardId)
+        } else {
+            return this.selectNextCard(
+                this.getAvailableCards(this.scenario.defaultState),
+            )
+        }
+    }
+
+    getAvailableCards(world: WorldState): CardData[] {
+        const { cards } = this.scenario
+        return cards.filter((c) =>
+            this.hasMatchingWorldQuery(world, c.isAvailableWhen),
+        )
+    }
+
+    getAvailableEvents(world: WorldState): WorldEvent[] {
+        const { events } = this.scenario
+        return events.filter((e) =>
+            this.hasMatchingWorldQuery(world, e.isAvailableWhen),
+        )
+    }
+
+    hasMatchingWorldQuery(
+        world: WorldState,
+        worldQueries: WorldQuery[],
+    ): Boolean {
+        return worldQueries.some((q) => this.isMatchingWorldQuery(world, q))
+    }
+
+    isMatchingWorldQuery(
+        world: WorldState,
+        { state = {}, flags = {} }: WorldQuery,
+    ): Boolean {
+        const hasStateMatch = Object.entries(state).every(
+            ([key, [min, max]]) =>
+                world.state[key] >= min && world.state[key] <= max,
+        )
+
+        const result =
+            hasStateMatch &&
+            Object.entries(flags).every(
+                ([flag, value]) => world.flags[flag] === value,
+            )
+
+        return result
+    }
+
+    onSwipe(card: CardData | EventCard, direction: SwipeDirection): void {
+        const currentAction =
+            direction === SwipeDirection.Left
+                ? card.actions.left
+                : card.actions.right
+
+        const updatedWorld = this.getUpdatedWorld(currentAction.modifier)
+
+        this.state.world = updatedWorld
+        this.state.card = this.getNextCard(updatedWorld, card, currentAction)
+        this.state.rounds = this.state.rounds + 1
+    }
+
+    getNextCard(
+        updatedWorld: WorldState,
+        card: CardData | EventCard,
+        currentAction: CardActionData | EventCardActionData,
+    ): CardData | EventCard {
+        const { eventCards } = this.scenario
+        const availableEvents = this.getAvailableEvents(updatedWorld)
+        let availableCards: CardData[] = []
+
+        const nextEventCardId: string | null =
+            card.type === 'event' && 'nextEventCardId' in currentAction
+                ? currentAction.nextEventCardId
+                : null
+        const eventStartingNow = !nextEventCardId
+            ? this.selectNextEvent(availableEvents)
+            : null
+        let nextCard
+
+        // Only select the next EventCard if a specific one is given
+        // Else cancel the event and continue with normal cards.
+        if (nextEventCardId) {
+            if (!eventCards.hasOwnProperty(nextEventCardId)) {
+                throw new Error(
+                    `eventCardId "${nextEventCardId}" does not exist. Make sure it's spelled correctly`,
+                )
+            }
+            nextCard = this.selectEventCard(nextEventCardId)
+        } else if (eventStartingNow) {
+            nextCard = this.selectEventCard(eventStartingNow.initialEventCardId)
+        } else {
+            availableCards = this.getAvailableCards(updatedWorld)
+            nextCard = this.selectNextCard(availableCards)
+        }
+
+        if (window.DEV_TOOLS_ACTIVE) {
+            window.DEV_TOOLS.game = {
+                world: this.state.world,
+                rounds: this.state.rounds,
+                card: this.state.card,
+            }
+
+            window.DEV_TOOLS.availableCards = availableCards
+            window.DEV_TOOLS.availableEvents = availableEvents
+
+            console.log('DEV TOOLS: ', window.DEV_TOOLS)
+        }
+
+        if (!nextCard) throw new Error('Content error. No next card available.')
+        return nextCard
+    }
+
+    getUpdatedWorld({
+        type = 'add',
+        state = {},
+        flags = {},
+    }: GameWorldModifier): WorldState {
+        // get default values for missing props by destructuring the incoming `modifier` and then directly reassembling it
+        // IDEA: Could this all be done in the function declaration, when specifying parameters?
+        const modifier: GameWorldModifier = { type, state, flags }
+        const updatedWorldState = this.updateWorldState(modifier)
+        const updatedWorldFlags = this.updateWorldFlags(modifier)
+
+        return {
+            state: updatedWorldState,
+            flags: updatedWorldFlags,
+        }
+    }
+
+    updateWorldState(modifier: GameWorldModifier): WorldState['state'] {
+        const currentWorldState: WorldState['state'] =
+            modifier.type === 'replace'
+                ? Object.assign({}, this.scenario.defaultState.state)
+                : Object.assign({}, this.state.world.state)
+
+        const stateModifier = modifier.state || {}
+        const updatedWorldState = Object.entries(stateModifier).reduce<
+            WorldState['state']
+        >((updatedState: WorldState['state'], [key, value]) => {
+            const newValue =
+                modifier.type === 'set' || modifier.type === 'replace'
+                    ? value
+                    : value + (updatedState[key] || 0)
+
+            updatedState[key] = Math.min(Math.max(newValue, 0), 100)
+
+            return updatedState
+        }, currentWorldState)
+
+        return updatedWorldState
+    }
+
+    updateWorldFlags(modifier: GameWorldModifier): WorldState['flags'] {
+        const currentWorldFlags: WorldState['flags'] =
+            modifier.type === 'replace'
+                ? Object.assign({}, this.scenario.defaultState.flags)
+                : Object.assign({}, this.state.world.flags)
+
+        const flagsModifier = modifier.flags || {}
+        const updatedWorldFlags = Object.entries(flagsModifier).reduce<
+            WorldState['flags']
+        >((updatedFlags, [key, value]) => {
+            updatedFlags[key] = value
+            return updatedFlags
+        }, currentWorldFlags)
+
+        return updatedWorldFlags
+    }
+
+    addUniqueCardId(
+        card: CardData | EventCard,
+        index: number = 0,
+    ): (CardData | EventCard) & { id: string } {
+        return {
+            ...card,
+            id: Date.now() + ':' + index,
+        }
+    }
+
+    selectNextCard(cards: CardData[] = []): CardData {
+        return this.selectWeightedRandomFrom(cards)
+    }
+
+    selectNextEvent(events: WorldEvent[] = []): WorldEvent | undefined {
+        const event = this.selectRandomFrom(events)
+        if (event && Math.random() <= event.probability) {
+            return event
+        }
+    }
+
+    selectRandomFrom<T>(array: T[]): T {
+        return array[Math.floor(Math.random() * array.length)]
+    }
+
+    selectWeightedRandomFrom<T extends { weight: number }>(
+        array: T[],
+        weightFunc = (element: T) => element.weight,
+    ): T {
+        const { selectionList, count } = array.reduce<{
+            count: number
+            selectionList: number[]
+        }>(
+            (acc, element) => {
+                acc.count += weightFunc(element)
+                acc.selectionList.push(acc.count)
+                return acc
+            },
+            { count: 0, selectionList: [] },
+        )
+
+        const selectionPosition = Math.random() * count
+        const selectionIndex = selectionList.findIndex((max, index, array) => {
+            const min = index > 0 ? array[index - 1] : 0
+            return selectionPosition >= min && selectionPosition <= max
+        })
+
+        return array[selectionIndex]
+    }
+
+    selectEventCard(cardId: EventCardId): EventCard {
+        const { eventCards } = this.scenario
+        const eventCard = eventCards[cardId]
+        if (!eventCard)
+            throw new Error(
+                `ContentError: EventCard with EventCardId "${cardId}" does not exist`,
+            )
+        return eventCard
+    }
+}

--- a/src/game/GameScenario.ts
+++ b/src/game/GameScenario.ts
@@ -43,27 +43,10 @@ type GameState = {
 // Could make debugging easier since the scenario could know it's ID.
 // Porentially, this could also allow us to remove the GameWorld Type and replace it with Scenario, which is much easier to understand.
 
-// IDEA: Keep React state separate from actual scenario
 // IDEA: Refactor into a set of pure functions that take can simulate a scenario deterministically. Maybe not use a class, but rather a set of functions
 // IDEA: Replace Math.random() usage and require all user code to pass in the random selection function, to ensure this module is deterministic.
 // IDEA: By keeping the GameScenario stateless, it will be easy to use both in game and in tests.
 // IDEA: Stateless It could also allow other uses, like training an AI to find the optimal endgame conditions, and the strategies used to get there.
-
-/* ----------------------- /*
-
-// IDEA: example usage for GameScenario
-import { getInitialState, getUpdatedState } from './GameScenario'
-
-// Raw data for current scenario
-const scenario: GameWorld = worldData
-
-// get initial state for the scenario
-let state = getInitialState(scenario)
-
-// Update state onSwipe. Then use new state however you want, either with setState() or directly in tests or similar.
-state = getUpdatedState(scenario, state, card, direction)
-
-/* ----------------------- */
 
 // IDEA: Ensure functions are pure by making copies of objects instead of passing by reference.
 //       This is especially important when using the default data `scenario` which shouldn't be mutated.

--- a/src/game/GameScenario.ts
+++ b/src/game/GameScenario.ts
@@ -1,3 +1,4 @@
+import { GameState } from './GameTypes'
 import {
     GameWorld,
     WorldState,
@@ -9,13 +10,7 @@ import {
     CardActionData,
     EventCardActionData,
     EventCardId,
-} from '../game/ContentTypes'
-
-type GameState = {
-    world: WorldState
-    card: CardData | EventCard
-    rounds: number
-}
+} from './ContentTypes'
 
 // TODO: break out dev tools and global state from this module, so the Game component itself handles that based on state
 // The new functional approach with this module will allow us to get deeper insights into how the game runs.

--- a/src/game/GameScenario.ts
+++ b/src/game/GameScenario.ts
@@ -1,5 +1,3 @@
-import { SwipeDirection } from '../util/constants'
-
 import {
     GameWorld,
     WorldState,
@@ -74,32 +72,23 @@ export function getInitialState(scenario: GameWorld): GameState {
  * @param scenario The scenario default data which holds all cards, events and similar
  * @param prevState The state before this update
  * @param card The currently visible card that the player is acting upon
- * @param direction Swipe direction used to determine the player's choosen action for how to move forward in the game
+ * @param action The player's choosen action for how to move forward in the game
  */
 export function getUpdatedState(
     scenario: GameWorld,
     prevState: GameState,
     card: CardData | EventCard,
-    direction: SwipeDirection,
+    action: CardActionData | EventCardActionData,
 ): GameState {
-    // IDEA: consider extracting this logic from the core GameScenario module, and simply pass in an `action` that should be used to update the gamge state.
-    // This would allow us to use more actions than just left + right in the future. Why not up/down too?
-    // It would also make it very clear that this function and this module ONLY is responsible for simulating game scenarios based on the minimum required inputs.
-    // User interactions could be handled by the game client, or by testing or by an AI.
-    const currentAction =
-        direction === SwipeDirection.Left
-            ? card.actions.left
-            : card.actions.right
-
     const updatedWorld = getUpdatedWorld(
         scenario,
-        currentAction.modifier,
+        action.modifier,
         prevState.world,
     )
 
     return {
         world: updatedWorld,
-        card: getNextCard(scenario, updatedWorld, card, currentAction),
+        card: getNextCard(scenario, updatedWorld, card, action),
         rounds: prevState.rounds + 1,
     }
 }
@@ -186,15 +175,15 @@ function getNextCard(
     scenario: GameWorld,
     updatedWorld: WorldState,
     card: CardData | EventCard,
-    currentAction: CardActionData | EventCardActionData,
+    action: CardActionData | EventCardActionData,
 ): CardData | EventCard {
     const { eventCards } = scenario
     const availableEvents = getAvailableEvents(scenario, updatedWorld)
     let availableCards: CardData[] = []
 
     const nextEventCardId: string | null =
-        card.type === 'event' && 'nextEventCardId' in currentAction
-            ? currentAction.nextEventCardId
+        card.type === 'event' && 'nextEventCardId' in action
+            ? action.nextEventCardId
             : null
     const eventStartingNow = !nextEventCardId
         ? selectNextEvent(availableEvents)

--- a/src/game/GameScenario.ts
+++ b/src/game/GameScenario.ts
@@ -99,6 +99,10 @@ export function getUpdatedState(
     card: CardData | EventCard,
     direction: SwipeDirection,
 ): GameState {
+    // IDEA: consider extracting this logic from the core GameScenario module, and simply pass in an `action` that should be used to update the gamge state.
+    // This would allow us to use more actions than just left + right in the future. Why not up/down too?
+    // It would also make it very clear that this function and this module ONLY is responsible for simulating game scenarios based on the minimum required inputs.
+    // User interactions could be handled by the game client, or by testing or by an AI.
     const currentAction =
         direction === SwipeDirection.Left
             ? card.actions.left

--- a/src/game/GameScenario.ts
+++ b/src/game/GameScenario.ts
@@ -68,6 +68,11 @@ state = getUpdatedState(scenario, state, card, direction)
 // IDEA: Ensure functions are pure by making copies of objects instead of passing by reference.
 //       This is especially important when using the default data `scenario` which shouldn't be mutated.
 
+/**
+ * Get the initial state for a given scenario.
+ *
+ * @param scenario The scenario default data which holds all cards, events and similar
+ */
 export function getInitialState(scenario: GameWorld): GameState {
     return {
         world: scenario.defaultState,
@@ -76,6 +81,18 @@ export function getInitialState(scenario: GameWorld): GameState {
     }
 }
 
+/**
+ * Get the updated state for a scenario based on previous state and the action taken to move forward.
+ *
+ * Since all dependencies are clearly stated throughout all child functions,
+ * it's really easy to change partial data and state to get a different updated state.
+ * This could be really useful for testing, or perhaps even some kind of AI to find the optimal actions/strategy
+ *
+ * @param scenario The scenario default data which holds all cards, events and similar
+ * @param prevState The state before this update
+ * @param card The currently visible card that the player is acting upon
+ * @param direction Swipe direction used to determine the player's choosen action for how to move forward in the game
+ */
 export function getUpdatedState(
     scenario: GameWorld,
     prevState: GameState,

--- a/src/game/GameScenario.ts
+++ b/src/game/GameScenario.ts
@@ -341,16 +341,3 @@ function selectWeightedRandomFrom<T extends { weight: number }>(
 
     return array[selectionIndex]
 }
-
-// NOTE: We might not need this function anymore since content will have unique id:s
-// IDEA: Move this to the Game component or perhaps even better - the GameWorld module - instead of keeping it here.
-
-export function addUniqueCardId(
-    card: CardData | EventCard,
-    index: number = 0,
-): (CardData | EventCard) & { id: string } {
-    return {
-        ...card,
-        id: Date.now() + ':' + index,
-    }
-}

--- a/src/game/GameTypes.ts
+++ b/src/game/GameTypes.ts
@@ -1,0 +1,10 @@
+import { WorldState, CardData, EventCard } from './ContentTypes'
+
+// NOTE: This might be moved to GameScenario if it's only used there.
+// The idea of separating Game types from Content types is to clarify what types will be useful for content development, and game development respectively.
+
+export type GameState = {
+    world: WorldState
+    card: CardData | EventCard
+    rounds: number
+}

--- a/src/game/GameTypes.ts
+++ b/src/game/GameTypes.ts
@@ -1,7 +1,6 @@
 import { WorldState, CardData, EventCard } from './ContentTypes'
 
-// NOTE: This might be moved to GameScenario if it's only used there.
-// The idea of separating Game types from Content types is to clarify what types will be useful for content development, and game development respectively.
+// GameTypes are used for the game implementation.
 
 export type GameState = {
     world: WorldState

--- a/src/game/load-scenario.ts
+++ b/src/game/load-scenario.ts
@@ -136,7 +136,7 @@ async function tryLoadFromRestAPI(path: string): Promise<GameWorld | null> {
     }
 }
 
-export async function loadGameWorld(path: string) {
+export async function loadScenario(path: string) {
     return (
         (await tryLoadFromInternalData(path)) ||
         (await tryLoadFromLocalStorage(path)) ||


### PR DESCRIPTION
Update 2020-06-08: The refactored `GameScenario` module will be used to simulate game state based on player actions. It's now playable and ready for a real review.

## What remains to do before this can be reviewed and merged?
- [x] Refactor `GameScenario` module to be functional, only exposing a minimal API. Move other code to `<Game />` instead.
- [x] Improve `GameScenario` module according to the comments found in the file.
- [x] Implement new GameState using the new API from the`GameScenario` module.
- [x] Re-implement dev tools in the `<Game />` UI component, sharing state with the `GameScenario`, but without being tightly coupled with it. This would be great as a separate component `<DevTools />` that could be rendered within `<Game />` and depend on it's `GameState`. Will be resolved with https://github.com/Greenheart/swipeforfuture.com/issues/116
- [X] Separate `SwipeDirection` handling from the `GameScenario` module. Instead, let the `Game` UI component handle that. Allow the scenario to update state based on an action. Makes it's API & implementation much cleaner. Fixed with https://github.com/Greenheart/swipeforfuture.com/pull/113/commits/1d71bd14feba2f8ee30a614dbb470b341a0fcfca
- [x] Figure out what to do with `GameTypes.ts`. Should we export the type and use across multiple files, or should we simply add it to `Game.ts` and import it in this one other place where it's needed? I propose the solution used in https://github.com/Greenheart/swipeforfuture.com/pull/113/commits/4424f2ef7fb000972ae3e6d45c6e83272e2284ea

I think the Dev tools could be implemented as a separate PR, to allow us to merge this one faster. If this sounds like a good idea, let's add a separate issue for this and remove the TODO from this PR. (see https://github.com/Greenheart/swipeforfuture.com/issues/116)

Note: This PR might be related to https://github.com/Greenheart/swipeforfuture.com/issues/54 but not entirely sure since that issue is pretty old.