### PR TITLE
fix!: apply world state extension to initial state

### DIFF
--- a/src/game/GameScenario.ts
+++ b/src/game/GameScenario.ts
@@ -65,7 +65,10 @@ export class BasicGameScenario implements GameScenario {
      */
     getInitialState(): GameState {
         return {
-            world: this._scenario.defaultState,
+            world: this.applyWorldStateExtensions(
+                this._worldStateExtensions,
+                this._scenario.defaultState,
+            ),
             card: this.getInitialCard(),
             rounds: 0,
         }


### PR DESCRIPTION
This fix will:
* make sure the world state extensions are applied properly
* specifically apply world state extensions to the initial state

This fix will affect the result of the initial state since the world state extensions are applied an additional time.
