### PR TITLE
Feature/allow selective debug

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -19,7 +19,7 @@ type GameProps = {
 }
 
 const Game: React.FunctionComponent<GameProps> = ({ scenario }) => {
-    const [state, setState] = useState<GameState>(scenario.getInitialState())
+    const [state, setState] = useState<GameState>(() => scenario.getInitialState())
 
     const card = addUniqueCardId(state.card)
     const worldState = state.world.state

--- a/src/game/ContentTypes.ts
+++ b/src/game/ContentTypes.ts
@@ -10,7 +10,7 @@ export type GameWorld = {
 }
 
 export type WorldStateModifier = {
-    type: "round" | "debug"
+    type: "round"
 } | {
     type: "cycle"
     id: string
@@ -19,6 +19,10 @@ export type WorldStateModifier = {
     type: "sum" | "min" | "max",
     sourceIds: string[],
     targetId: string,
+} | {
+    type: "debug"
+    stateIds?: string[]
+    flagIds?: string[]
 }
 
 export type WorldState = {


### PR DESCRIPTION
This PR will:
* add support for specifying which state and flag parameters to log when using debug extension
* fix a `bug` where the initial state was fetched multiple times which caused the WorldStateExtensions to be applied too often (Only affected the debug extension since it had side effects)

To test:
* checkout branch and run
* test with content that uses the new parameters `stateIds` and `flagIds`
```
{
  type: "debug",
  stateIds: ["environment"],
  flagIds: ["lunch-meeting-completed"]
}
```