### PR TITLE
feat(style): experimental style adjustment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,9 +12,9 @@ const Container = styled.main`
     left: 0;
     width: 100vw;
     height: 100%;
-    background: #546a76;
-    display: grid;
-    grid-template-rows: minmax(50px, 80px) auto minmax(50px, 80px);
+    background: #ccdddd;
+    display: flex;
+    flex-direction: column;
 `
 const GlobalStyles = createGlobalStyle`
     * {

--- a/src/components/Bar.tsx
+++ b/src/components/Bar.tsx
@@ -2,20 +2,17 @@ import React from 'react'
 import styled from 'styled-components/macro'
 
 const Container = styled.div`
-    margin-top: 10px;
-    width: 40px;
-    height: 8px;
-    border-radius: 4px;
-    background: #546a76;
+    width: 5vh;
+    height: 1vh;
+    background: #333;
+    box-shadow: 0 0.2vh 0.2vh rgba(0, 0, 0, 0.2);
 `
 
-const Value = styled.div`
+const Value = styled.div<{ value: number }>`
+    width: ${(props) => props.value + '%'};
     position: relative;
-    top: 1px;
-    left: 1px;
-    height: 6px;
-    max-width: 38px;
-    border-radius: 3px;
+    height: 100%;
+    background: #fff;
 `
 
 type BarProps = {
@@ -24,23 +21,8 @@ type BarProps = {
 
 const Bar: React.FunctionComponent<BarProps> = ({ value = 100 }) => (
     <Container>
-        <Value
-            style={{
-                width: `${value}%`,
-                backgroundColor: getBarColor(value),
-            }}
-        />
+        <Value value={value} />
     </Container>
 )
-
-function getBarColor(value: number): string {
-    if (value <= 30) {
-        return '#dd7373'
-    } else if (value <= 70) {
-        return '#e7e247'
-    } else {
-        return '#91c779'
-    }
-}
 
 export default Bar

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -19,12 +19,12 @@ type AnimationState = {
 
 const to = (i: number): AnimationState => ({
     x: 0,
-    y: 0,
+    y: -30,
     scale: 1,
     rot: 0,
     delay: i * 100,
 })
-const from = (): AnimationState => ({ rot: 0, scale: 1.0, y: 10, x: 0 })
+const from = (): AnimationState => ({ rot: 0, scale: 1.0, y: -20, x: 0 })
 
 const trans = (r: number, s: number) =>
     `perspective(1500px) rotate3d(1, 0, 0, 30deg) rotate3d(0, 0, 1, ${r}deg) scale(${s})`
@@ -52,7 +52,7 @@ const Card: React.FunctionComponent<CardProps> = ({
         ...to(i),
         from: from(),
     }))
-    const [directionPreview, setDirectionPreview] = useState<number>(0);
+    const [directionPreview, setDirectionPreview] = useState<number>(0)
 
     const [cardState] = useState<{
         isGone: boolean
@@ -84,7 +84,7 @@ const Card: React.FunctionComponent<CardProps> = ({
                 cardState.currentKey = null
             }, 200)
         }
-        setDirectionPreview(down ? dir : 0);
+        setDirectionPreview(down ? dir : 0)
         const isGone = cardState.isGone
 
         const x = isGone ? (200 + window.innerWidth) * dir : down ? xDelta : 0
@@ -140,8 +140,9 @@ const Card: React.FunctionComponent<CardProps> = ({
                 transform: interpolate(
                     [x, y, rot, scale as any],
                     (x: number, y: number, rot: number, scale: number) =>
-                        `translate3d(-50%, 0, 0) translate3d(${x}px,${y}px,0) ` +
-                        trans(rot, Number(scale)),
+                        `translate3d(-50%, 0, 0) translate3d(${x * 0.15}vh,${
+                            y * 0.15
+                        }vh,0) ` + trans(rot, Number(scale)),
                 ),
                 zIndex: layer,
             }}

--- a/src/components/CardView.tsx
+++ b/src/components/CardView.tsx
@@ -21,27 +21,32 @@ type CardProps = {
 
 function cardSize(
     scale: number,
-): ((props: {theme: {cardWidth: (s: number) => string}}) => string) {
-    return ({theme: {cardWidth}}: {theme: {cardWidth: (s: number) => string}}) => cardWidth(scale);
+): (props: { theme: { cardWidth: (s: number) => string } }) => string {
+    return ({
+        theme: { cardWidth },
+    }: {
+        theme: { cardWidth: (s: number) => string }
+    }) => cardWidth(scale)
 }
 
-const borderRadius = cardSize(0.035);
-const cardWidth = cardSize(1);
-const cardHeight = cardSize(2);
-const actionWidth = cardSize(0.5);
-const minActionWidth = cardSize(0.25);
-const largePadding = cardSize(0.125);
-const halfLargePadding = cardSize(0.0625);
-const quadPadding = cardSize(0.1);
-const doublePadding = cardSize(0.05);
-const mediumPadding = cardSize(0.025);
-const halfPadding = cardSize(0.0125);
-const locationPosition = cardSize(-0.1125);
+const borderRadius = cardSize(0.035)
+const cardWidth = cardSize(1)
+const cardHeight = cardSize(2)
+const actionWidth = cardSize(0.5)
+const minActionWidth = cardSize(0.25)
+const largePadding = cardSize(0.125)
+const halfLargePadding = cardSize(0.0625)
+const quadPadding = cardSize(0.1)
+const doublePadding = cardSize(0.05)
+const mediumPadding = cardSize(0.025)
+const halfPadding = cardSize(0.0125)
+const locationPosition = cardSize(-0.1125)
 
 const CardContent = styled.div`
     font-size: ${borderRadius};
 
-    & > .action-left, & > .action-right {
+    & > .action-left,
+    & > .action-right {
         font-size: 160%;
         background: #fff;
         position: absolute;
@@ -133,9 +138,7 @@ const CardContent = styled.div`
                 font-size: 140%;
                 background: rgba(230, 230, 230, 0.7);
                 border-radius: 1vh 0 0 1vh;
-                padding: ${halfPadding}
-                    ${largePadding}
-                    ${halfPadding}
+                padding: ${halfPadding} ${largePadding} ${halfPadding}
                     ${doublePadding};
             }
 
@@ -146,16 +149,13 @@ const CardContent = styled.div`
                 background: #333;
                 display: block;
                 margin: 0;
-                padding: ${mediumPadding}
-                    ${halfLargePadding};
+                padding: ${mediumPadding} ${halfLargePadding};
             }
 
             & > p.text {
                 font-size: 160%;
                 color: #333;
-                padding: ${doublePadding}
-                    ${halfLargePadding}
-                    ${quadPadding}
+                padding: ${doublePadding} ${halfLargePadding} ${quadPadding}
                     ${halfLargePadding};
                 margin: 0;
             }
@@ -175,8 +175,9 @@ const CardContent = styled.div`
 `
 CardContent.defaultProps = {
     theme: {
-        cardWidth: (value: number) => value * 40 + 'vh',
-        cardBackImage: 'https://images.unsplash.com/photo-1550537687-c91072c4792d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=80', 
+        cardWidth: (value: number) => value * 45 + 'vh',
+        cardBackImage:
+            'https://images.unsplash.com/photo-1550537687-c91072c4792d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=80',
     },
 }
 
@@ -203,12 +204,22 @@ export const CardView: React.SFC<CardProps> = ({
                 <p className="text">{text}</p>
             </div>
         </div>
-        <div className={"action-left" + (direction === SwipeDirection.Left ? " active" : "")}>
-            <div className="description">{leftAction ?? "No"}</div>
+        <div
+            className={
+                'action-left' +
+                (direction === SwipeDirection.Left ? ' active' : '')
+            }
+        >
+            <div className="description">{leftAction ?? 'No'}</div>
             <div className="arrow">&larr;</div>
         </div>
-        <div className={"action-right" + (direction === SwipeDirection.Right ? " active" : "")}>
-            <div className="description">{rightAction ?? "Yes"}</div>
+        <div
+            className={
+                'action-right' +
+                (direction === SwipeDirection.Right ? ' active' : '')
+            }
+        >
+            <div className="description">{rightAction ?? 'Yes'}</div>
             <div className="arrow">&rarr;</div>
         </div>
     </CardContent>
@@ -224,7 +235,9 @@ export const DummyCard: React.FunctionComponent<DummyCardProps> = ({
         style={{
             position: 'absolute',
             left: '50%',
-            transform: `translate3d(-50%, 0, 0) translate3d(${x}px, ${y}px, 0) perspective(1500px) rotate3d(1, 0, 0, 30deg) rotate3d(0, 0, 1, ${r}deg)`,
+            transform: `translate3d(-50%, 0, 0) translate3d(${x * 0.15}vh, ${
+                y * 0.15
+            }vh, 0) perspective(1500px) rotate3d(1, 0, 0, 30deg) rotate3d(0, 0, 1, ${r}deg)`,
             transition: 'transform 0.3s',
             zIndex: layer,
         }}

--- a/src/components/CardView.tsx
+++ b/src/components/CardView.tsx
@@ -175,7 +175,7 @@ const CardContent = styled.div`
 `
 CardContent.defaultProps = {
     theme: {
-        cardWidth: (value: number) => value * 45 + 'vh',
+        cardWidth: (value: number) => value * 40 + 'vh',
         cardBackImage:
             'https://images.unsplash.com/photo-1550537687-c91072c4792d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=80',
     },

--- a/src/components/Deck.tsx
+++ b/src/components/Deck.tsx
@@ -23,7 +23,7 @@ const Deck: React.FunctionComponent<DeckProps> = ({
                 <DummyCard
                     x={0}
                     y={
-                        10 +
+                        -20 +
                         list[loopingIndex(index, list.length, tick)] *
                             (50 / list.length)
                     }

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -15,7 +15,6 @@ const Container = styled.header`
     flex-direction: row;
     justify-content: center;
     align-items: center;
-    gap: 3.5vh;
     flex-basis: 10vh;
     flex-grow: 0;
     flex-shrink: 0;
@@ -28,7 +27,11 @@ const Stat = styled.div`
     justify-content: space-between;
     align-items: center;
     flex-direction: column;
-    gap: 1vh;
+    margin-right: 3.5vh;
+
+    &:last-child {
+        margin-right: 0;
+    }
 `
 
 const Icon = styled.div`
@@ -41,6 +44,7 @@ const Icon = styled.div`
     justify-content: center;
     align-items: center;
     box-shadow: 0 0.3vh 0.3vh rgba(0, 0, 0, 0.2);
+    margin-bottom: 1vh;
 `
 type StatsProps = {
     stats: (StatDefinition & { value: number })[]

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -28,7 +28,7 @@ const Stat = styled.div`
     justify-content: space-between;
     align-items: center;
     flex-direction: column;
-    gap: 0.5vh;
+    gap: 1vh;
 `
 
 const Icon = styled.div`

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -10,11 +10,17 @@ import Bar from './Bar'
 import { StatDefinition } from '../game/ContentTypes'
 
 const Container = styled.header`
-    background: #f6fbf5;
+    background: #66aa55;
     display: flex;
     flex-direction: row;
-    justify-content: space-evenly;
+    justify-content: center;
     align-items: center;
+    gap: 3.5vh;
+    flex-basis: 10vh;
+    flex-grow: 0;
+    flex-shrink: 0;
+    border-bottom: solid 0.5vh #fff;
+    box-shadow: 0 0.2vh 0.5vh rgba(0, 0, 0, 0.5);
 `
 
 const Stat = styled.div`
@@ -22,17 +28,19 @@ const Stat = styled.div`
     justify-content: space-between;
     align-items: center;
     flex-direction: column;
+    gap: 0.5vh;
 `
 
 const Icon = styled.div`
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    background: #91c779;
+    width: 5vh;
+    height: 5vh;
+    border-radius: 50% 0;
+    background: #fff;
 
     display: flex;
     justify-content: center;
     align-items: center;
+    box-shadow: 0 0.3vh 0.3vh rgba(0, 0, 0, 0.2);
 `
 type StatsProps = {
     stats: (StatDefinition & { value: number })[]


### PR DESCRIPTION
Adjusts the styling:
* note that the biggest size difference is in mobile landscape
* use `vh` in most places in order to make the sizes consistent
* remove colors from value bars
* remove rounded corners from value bars
* increase size of value bars
* adjust styling of icon container
* group stats content tighter together

Depending on preference it might seem a bit small on mobile portrait. I considered keeping it as it was but preferred consistency in sizing rather than a larger mobile portrait. I would argue that the game should not be played in mobile portrait. :P

To test:
* checkout and run
* verify that the game can be played in different sizes
* preferrably test on actual mobile device