### PR TITLE
feature(GameScenario): Add support for multiple GameWorldModifiers

### DIFF
--- a/src/game/ContentTypes.ts
+++ b/src/game/ContentTypes.ts
@@ -9,21 +9,25 @@ export type GameWorld = {
     worldStateModifiers: WorldStateModifier[]
 }
 
-export type WorldStateModifier = {
-    type: "round"
-} | {
-    type: "cycle"
-    id: string
-    length: number
-} | {
-    type: "sum" | "min" | "max",
-    sourceIds: string[],
-    targetId: string,
-} | {
-    type: "debug"
-    stateIds?: string[]
-    flagIds?: string[]
-}
+export type WorldStateModifier =
+    | {
+          type: 'round'
+      }
+    | {
+          type: 'cycle'
+          id: string
+          length: number
+      }
+    | {
+          type: 'sum' | 'min' | 'max'
+          sourceIds: string[]
+          targetId: string
+      }
+    | {
+          type: 'debug'
+          stateIds?: string[]
+          flagIds?: string[]
+      }
 
 export type WorldState = {
     state: {
@@ -55,7 +59,7 @@ export type GameWorldModifier = Partial<WorldState> & {
 
 export interface CardActionData {
     description?: string
-    modifier: GameWorldModifier
+    modifiers: GameWorldModifier[]
 }
 
 export interface CardData extends CardDescription {

--- a/src/game/GameScenario.ts
+++ b/src/game/GameScenario.ts
@@ -89,7 +89,7 @@ export class BasicGameScenario implements GameScenario {
         action: CardActionData | EventCardActionData,
     ): GameState {
         const updatedWorld = this.getUpdatedWorld(
-            action.modifier,
+            action.modifiers,
             prevState.world,
         )
 
@@ -101,17 +101,24 @@ export class BasicGameScenario implements GameScenario {
     }
 
     getUpdatedWorld(
-        inputModifier: GameWorldModifier,
+        inputModifiers: GameWorldModifier[],
         world: WorldState,
     ): WorldState {
-        const modifier: GameWorldModifier = {
+        const modifiers: GameWorldModifier[] = inputModifiers.map((mod) => ({
             type: 'add',
             state: {},
             flags: {},
-            ...inputModifier,
-        }
-        const updatedWorldState = this.updateWorldState(modifier, world)
-        const updatedWorldFlags = this.updateWorldFlags(modifier, world)
+            ...mod,
+        }))
+        const updatedWorldState = modifiers.reduce<WorldState['state']>(
+            (acc, mod) => this.updateWorldState(mod, { state: acc, flags: {} }),
+            world.state,
+        )
+        const updatedWorldFlags = modifiers.reduce<WorldState['flags']>(
+            (acc, mod) => this.updateWorldFlags(mod, { state: {}, flags: acc }),
+            world.flags,
+        )
+
         const newWorld = this.applyWorldStateExtensions(
             this._worldStateExtensions,
             {


### PR DESCRIPTION
This will for example allow combining `set` and `add`, which is useful to create cards that both need to set flags to specific states, while also applying regular `add` modifiers to the game world state.