### PR TITLE
refactor: replace GameScenario with a more generic Game type

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components/macro'
 import { createGlobalStyle } from 'styled-components'
 
 import Game from './components/Game'
-import { GameScenario, BasicGameScenario } from './game/GameScenario'
+import { Game as GameLogic, BasicGameScenario } from './game'
+import { WorldState } from './game/ContentTypes'
 import { loadScenario } from './game/load-scenario'
 
 const Container = styled.main`
@@ -38,23 +39,23 @@ type AppProps = {
 }
 
 function App({ path }: AppProps) {
-    const [scenario, setScenario] = useState<GameScenario | null>(null)
+    const [game, setGame] = useState<GameLogic<WorldState> | null>(null)
     useEffect(() => {
         const fetchWorld = async () => {
             const scenarioData = await loadScenario(path)
             if (scenarioData) {
                 const instance = BasicGameScenario.fromData(scenarioData)
-                setScenario(instance)
+                setGame(instance)
             } else {
                 console.warn('Scenario loading error')
             }
         }
         fetchWorld()
-    }, [path, setScenario])
+    }, [path, setGame])
     return (
         <Container>
             <GlobalStyles />
-            {scenario && <Game scenario={scenario} />}
+            {game && <Game game={game} />}
         </Container>
     )
 }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -6,8 +6,8 @@ import { useSpring } from 'react-spring'
 import { useGesture, GestureState } from 'react-with-gesture'
 
 import { useKeyboardEvent } from '../util/hooks'
-import { CardData, EventCard } from '../game/ContentTypes'
 import { SwipeDirection } from '../util/constants'
+import { CardPresentation } from '../game/Types'
 
 type AnimationState = {
     x: number
@@ -35,18 +35,18 @@ const getThreshold = () => Math.min(200, window.innerWidth / 2)
 
 type CardProps = {
     i: number
-    cardData: CardData | EventCard
-    onSwipe: (card: CardData | EventCard, direction: SwipeDirection) => void
+    card: CardPresentation
+    onSwipe: (direction: SwipeDirection) => void
     layer: number
 }
 
-const Card: React.FunctionComponent<CardProps> = ({
+export const Card: React.FunctionComponent<CardProps> = ({
     i,
-    cardData,
+    card,
     onSwipe,
     layer,
 }) => {
-    const { title, location, text, image, actions } = cardData
+    const { title, location, text, image, actions } = card
 
     const [cardAnimationState, setCardAnimationState] = useSpring(() => ({
         ...to(i),
@@ -80,7 +80,7 @@ const Card: React.FunctionComponent<CardProps> = ({
             // Handle game state updates
             cardState.isGone = true
             window.setTimeout(() => {
-                onSwipe(cardData, dir)
+                onSwipe(dir)
                 cardState.currentKey = null
             }, 200)
         }
@@ -159,5 +159,3 @@ const Card: React.FunctionComponent<CardProps> = ({
         </animated.div>
     )
 }
-
-export default Card

--- a/src/components/Deck.tsx
+++ b/src/components/Deck.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 
-import Card from './Card'
+import { Card } from './Card'
 import { DummyCard } from './CardView'
-
-import { CardData, EventCard } from '../game/ContentTypes'
 import { SwipeDirection } from '../util/constants'
+import { CardPresentation } from '../game/Types'
 
 type DeckProps = {
-    onSwipe: (card: CardData | EventCard, direction: SwipeDirection) => void
-    card: (CardData | EventCard) & { id: string }
+    onSwipe: (direction: SwipeDirection) => void
+    card: CardPresentation
     tick: number
 }
 const Deck: React.FunctionComponent<DeckProps> = ({
@@ -34,8 +33,8 @@ const Deck: React.FunctionComponent<DeckProps> = ({
             ))}
             <Card
                 i={0}
-                key={card.id}
-                cardData={card}
+                key={tick}
+                card={card}
                 onSwipe={onSwipe}
                 layer={cardStack.length + 1}
             />

--- a/src/game/Types.ts
+++ b/src/game/Types.ts
@@ -1,0 +1,49 @@
+export type Stat<P> = {
+    getValue: (state: GameState<P>) => number
+    id: string
+    name: string
+    icon: string
+    iconSize?: string
+}
+
+export type StateModifier<P> = (state: GameState<P>) => GameState<P>
+
+export interface CardAction<P> {
+    description: string
+    modifier: StateModifier<P>
+}
+
+export type CardPresentation = {
+    image: string
+    title: string
+    text: string
+    location: string
+    actions: {
+        left: {
+            description: string
+        }
+        right: {
+            description: string
+        }
+    }
+}
+
+export interface Card<P> extends CardPresentation {
+    match(state: GameState<P>): boolean
+    weight: number
+    actions: {
+        left: CardAction<P>
+        right: CardAction<P>
+    }
+}
+
+export type GameState<P> = {
+    card?: Card<P>
+    params: P
+}
+
+export interface Game<P> {
+    initialState: GameState<P>
+    applyAction(prevState: GameState<P>, action: StateModifier<P>): GameState<P>
+    stats: Stat<P>[]
+}

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -1,0 +1,2 @@
+export * from './Types'
+export * from './GameScenario'


### PR DESCRIPTION
This branch should clean up some component code and prepare for use of a more generic Game concept. This PR will:
* Remove the GameScenario concept
* Add the Game\<P\> concept
* Make BasicGameScenario use the Game\<P\> concept
* Make Game component use Game\<P\> concept
* Remove type specificity from components Deck and Card

This PR should not change any user facing behaviour.

To test:
* Build and run `npm start`
* Fixed by new content build. ~Make sure you are using latest data with `modifiers` and not `modifier` (currently the target online data is a mismatch)~
* Verify that the game behaves as expected

