### PR TITLE
WIP: Feature/simplify game types

### DIFF
--- a/src/game/BasicGame.ts
+++ b/src/game/BasicGame.ts
@@ -87,17 +87,6 @@ export class BasicGame<P> implements Game<P> {
         array: T[],
         weightFunc = (element: T) => element.weight,
     ): T {
-        // IDEA 1:  Add custom weight function to calculate weight based on priority
-
-        // IDEA 2:  Update card priority to be called card weight instead and then just use that value
-        //          For this to work, we need to change the CardPriority Enum to use Card = 1 and Event = 2
-
-        //          However, it might cause problems since it won't sort out cards with higher priority to get selected first.
-
-        // IDEA 3:  Update _getAvailableCards() to take priority into account and only return the set of cards with the highest priority
-        //          This way, we can use both `priority` to distinguish between events and regular cards,
-        //          and we can also use the `weight` to determine the mutual priority among the cards of a similar type.
-
         const { selectionList, count } = array.reduce<{
             count: number
             selectionList: number[]

--- a/src/game/BasicGame.ts
+++ b/src/game/BasicGame.ts
@@ -65,13 +65,39 @@ export class BasicGame<P> implements Game<P> {
     }
 
     private _getAvailableCards(state: GameState<P>): Card<P>[] {
-        return this._cards.filter((c) => c.match(state))
+        // First do regular matching based on game state.
+        const allAvailable = this._cards.filter((c) => c.match(state))
+
+        const cardsByPriority: Record<number, Card<P>[]> = {}
+
+        for (const card of allAvailable) {
+            cardsByPriority[card.priority] = cardsByPriority[card.priority]
+                ? cardsByPriority[card.priority].concat(card)
+                : [card]
+        }
+
+        // Then select the available set of cards with the highest priority.
+        let highestPriority = Math.min(
+            ...Object.keys(cardsByPriority).map((n) => parseInt(n, 10)),
+        )
+        return cardsByPriority[highestPriority]
     }
 
     private _selectWeightedRandomFrom<T extends { weight: number }>(
         array: T[],
         weightFunc = (element: T) => element.weight,
     ): T {
+        // IDEA 1:  Add custom weight function to calculate weight based on priority
+
+        // IDEA 2:  Update card priority to be called card weight instead and then just use that value
+        //          For this to work, we need to change the CardPriority Enum to use Card = 1 and Event = 2
+
+        //          However, it might cause problems since it won't sort out cards with higher priority to get selected first.
+
+        // IDEA 3:  Update _getAvailableCards() to take priority into account and only return the set of cards with the highest priority
+        //          This way, we can use both `priority` to distinguish between events and regular cards,
+        //          and we can also use the `weight` to determine the mutual priority among the cards of a similar type.
+
         const { selectionList, count } = array.reduce<{
             count: number
             selectionList: number[]

--- a/src/game/ContentTypes.ts
+++ b/src/game/ContentTypes.ts
@@ -64,7 +64,6 @@ export interface CardActionData {
     description?: string
     modifiers: GameWorldModifier[]
     next?: Card['id']
-    priority?: CardPriority
 }
 
 export interface Card extends CardDescription {
@@ -74,6 +73,7 @@ export interface Card extends CardDescription {
         left: CardActionData
         right: CardActionData
     }
+    priority?: CardPriority
 }
 
 export type WorldStateRange = [number, number]

--- a/src/game/ContentTypes.ts
+++ b/src/game/ContentTypes.ts
@@ -2,7 +2,7 @@
 
 export type GameWorld = {
     stats: StatDefinition[]
-    cards: Cards
+    cards: Card[]
     defaultState: WorldState
     worldStateModifiers: WorldStateModifier[]
 }
@@ -55,10 +55,16 @@ export type GameWorldModifier = Partial<WorldState> & {
     type?: 'add' | 'set' | 'replace'
 }
 
+export enum CardPriority {
+    Event = 0,
+    Card = 1
+}
+
 export interface CardActionData {
     description?: string
     modifiers: GameWorldModifier[]
     next?: Card['id']
+    priority?: CardPriority
 }
 
 export interface Card extends CardDescription {
@@ -68,10 +74,6 @@ export interface Card extends CardDescription {
         left: CardActionData
         right: CardActionData
     }
-}
-
-export interface Cards {
-    [id: string]: Card
 }
 
 export type WorldStateRange = [number, number]

--- a/src/game/ContentTypes.ts
+++ b/src/game/ContentTypes.ts
@@ -2,9 +2,7 @@
 
 export type GameWorld = {
     stats: StatDefinition[]
-    cards: CardData[]
-    events: WorldEvent[]
-    eventCards: EventCards
+    cards: Cards
     defaultState: WorldState
     worldStateModifiers: WorldStateModifier[]
 }
@@ -60,15 +58,20 @@ export type GameWorldModifier = Partial<WorldState> & {
 export interface CardActionData {
     description?: string
     modifiers: GameWorldModifier[]
+    next?: Card['id']
 }
 
-export interface CardData extends CardDescription {
-    type: 'card'
+export interface Card extends CardDescription {
+    id: string
     isAvailableWhen: WorldQuery[]
     actions: {
         left: CardActionData
         right: CardActionData
     }
+}
+
+export interface Cards {
+    [id: string]: Card
 }
 
 export type WorldStateRange = [number, number]
@@ -80,36 +83,4 @@ export interface WorldQuery {
     flags?: {
         [x: string]: boolean
     }
-}
-
-/**
- * WorldEvents start with a specific card and then offer full control to show EventCards in any order you like.
- * This makes WorldEvents great for story where you as a scenario creator want more control.
- *
- * @param initialEventCardId Used to find the EventCard to start the event with
- * @param isAvailableWhen An array of WorldQueries. If any of them match, the event is available for selection.
- * @param probability When any WorldQuery match and makes this event available, this probability defines how likely this event will trigger.
- */
-export interface WorldEvent {
-    initialEventCardId: EventCardId
-    isAvailableWhen: WorldQuery[]
-    probability: number
-}
-
-export type EventCards = {
-    [eventCardId: string]: EventCard
-}
-
-export interface EventCard extends CardDescription {
-    type: 'event'
-    actions: {
-        left: EventCardActionData
-        right: EventCardActionData
-    }
-}
-
-export type EventCardId = string
-
-export interface EventCardActionData extends CardActionData {
-    nextEventCardId: EventCardId | null
 }

--- a/src/game/ContentTypes.ts
+++ b/src/game/ContentTypes.ts
@@ -73,7 +73,7 @@ export interface Card extends CardDescription {
         left: CardActionData
         right: CardActionData
     }
-    priority?: CardPriority
+    priority: CardPriority
 }
 
 export type WorldStateRange = [number, number]

--- a/src/game/GameTypes.ts
+++ b/src/game/GameTypes.ts
@@ -1,9 +1,9 @@
-import type { WorldState, CardData, EventCard } from './ContentTypes'
+import type { WorldState, Card } from './ContentTypes'
 
 // GameTypes are used for the game implementation.
 
 export type GameState = {
     world: WorldState
-    card: CardData | EventCard
+    card: Card
     rounds: number
 }

--- a/src/game/GameWorldLoader.ts
+++ b/src/game/GameWorldLoader.ts
@@ -1,9 +1,8 @@
-import {
+import type {
     GameWorld,
     GameWorldModifier,
     CardActionData,
     WorldQuery,
-    CardPriority,
 } from './ContentTypes'
 import type {
     Game,
@@ -106,7 +105,7 @@ function cardFromData(
             left: actionFromData(data.actions.left, defaultParams, 'No'),
             right: actionFromData(data.actions.right, defaultParams, 'Yes'),
         },
-        priority: data.priority ?? CardPriority.Card,
+        priority: data.priority,
     }
 }
 

--- a/src/game/GameWorldLoader.ts
+++ b/src/game/GameWorldLoader.ts
@@ -84,6 +84,7 @@ function cardFromData(
         'isAvailableWhen' in data ? data.isAvailableWhen : []
     ).map(worldQueryToParamQuery)
     return {
+        id: data.id,
         image: data.image,
         title: data.title,
         text: data.text,
@@ -94,6 +95,7 @@ function cardFromData(
             left: actionFromData(data.actions.left, defaultParams, 'No'),
             right: actionFromData(data.actions.right, defaultParams, 'Yes'),
         },
+        priority: data.priority
     }
 }
 
@@ -113,6 +115,7 @@ function actionFromData(
     return {
         description: data.description ?? defaultDescription,
         modifier: (state) => updateParams(state, data.modifiers, defaultParams),
+        next: data.next
     }
 }
 

--- a/src/game/GameWorldLoader.ts
+++ b/src/game/GameWorldLoader.ts
@@ -1,8 +1,9 @@
-import type {
+import {
     GameWorld,
     GameWorldModifier,
     CardActionData,
     WorldQuery,
+    CardPriority,
 } from './ContentTypes'
 import type {
     Game,
@@ -42,11 +43,7 @@ export function load(
     }, {})
 
     const cards = cardsFromData(cardsMap, defaultParams)
-
-    console.log(cards)
-
-    // TODO: Add runtime capability to select event cards first based on `priority`
-    // TODO: Add runtime capability to move to the specific next card when it's selected.
+    console.log(`Loaded cards:`, cards)
 
     const parameterCaps = parameterCapsFromStats(gameWorld.stats)
     const stats = statsFromData(gameWorld.stats)
@@ -109,7 +106,7 @@ function cardFromData(
             left: actionFromData(data.actions.left, defaultParams, 'No'),
             right: actionFromData(data.actions.right, defaultParams, 'Yes'),
         },
-        priority: data.priority,
+        priority: data.priority ?? CardPriority.Card,
     }
 }
 

--- a/src/game/GameWorldLoader.ts
+++ b/src/game/GameWorldLoader.ts
@@ -9,7 +9,6 @@ import type {
     GameState,
     Card,
     CardAction,
-    StateModifier,
     Stat,
 } from './Types'
 import { Params, ParamQuery, hasMatchingParamQuery } from './Params'
@@ -32,7 +31,7 @@ export function load(
         flags: gameWorld.defaultState.flags,
         vars: gameWorld.defaultState.state,
     }
-    const cards = Object.values(gameWorld.cards).map<Card<Params>>((data) =>
+    const cards = gameWorld.cards.map<Card<Params>>((data) =>
         cardFromData(data, defaultParams),
     )
     const parameterCaps = parameterCapsFromStats(gameWorld.stats)
@@ -40,7 +39,7 @@ export function load(
     const stateExtensions = stateExtensionsFromData(
         gameWorld.worldStateModifiers,
     )
-    return new BasicGame<Params>([...cards], stats, defaultParams, {
+    return new BasicGame<Params>(cards, stats, defaultParams, {
         tickModifiers: [ ...stateExtensions, parameterCaps],
         random,
     })

--- a/src/game/Types.ts
+++ b/src/game/Types.ts
@@ -11,6 +11,7 @@ export type StateModifier<P> = (state: GameState<P>) => GameState<P>
 export interface CardAction<P> {
     description: string
     modifier: StateModifier<P>
+    next?: Card<P>['id']
 }
 
 export type CardPresentation = {
@@ -29,12 +30,14 @@ export type CardPresentation = {
 }
 
 export interface Card<P> extends CardPresentation {
+    id: string
     match(state: GameState<P>): boolean
     weight: number
     actions: {
         left: CardAction<P>
         right: CardAction<P>
     }
+    priority?: number
 }
 
 export type GameState<P> = {

--- a/src/game/Types.ts
+++ b/src/game/Types.ts
@@ -1,3 +1,5 @@
+import type { GameWorld } from "./ContentTypes"
+
 export type Stat<P> = {
     getValue: (state: GameState<P>) => number
     id: string
@@ -39,6 +41,8 @@ export interface Card<P> extends CardPresentation {
     }
     priority?: number
 }
+
+export type CardsMap<P> = Record<Card<P>['id'], Card<P>>
 
 export type GameState<P> = {
     card?: Card<P>

--- a/src/game/Types.ts
+++ b/src/game/Types.ts
@@ -39,7 +39,7 @@ export interface Card<P> extends CardPresentation {
         left: CardAction<P>
         right: CardAction<P>
     }
-    priority?: number
+    priority: number
 }
 
 export type CardsMap<P> = Record<Card<P>['id'], Card<P>>

--- a/src/game/load-scenario.ts
+++ b/src/game/load-scenario.ts
@@ -1,12 +1,4 @@
-import type {
-    WorldState,
-    StatDefinition,
-    CardData,
-    EventCards,
-    WorldEvent,
-    GameWorld,
-    WorldStateModifier,
-} from './ContentTypes'
+import type { GameWorld } from './ContentTypes'
 
 async function tryLoadFromLocalStorage(
     path: string,
@@ -20,9 +12,7 @@ async function tryLoadFromLocalStorage(
         const gameWorldId = 'game_world:' + id
         const gameWorld: GameWorld = {
             stats: [],
-            cards: [],
-            events: [],
-            eventCards: {},
+            cards: {},
             defaultState: {
                 state: {},
                 flags: {},

--- a/src/game/load-scenario.ts
+++ b/src/game/load-scenario.ts
@@ -41,6 +41,6 @@ export async function loadScenario(path: string): Promise<GameWorld | null> {
 }
 
 async function fetchJSON<T>(path: string): Promise<T> {
-    console.log('fetching path: ', path)
+    console.log('Fetching path: ', path)
     return await (await window.fetch(path)).json()
 }

--- a/src/game/load-scenario.ts
+++ b/src/game/load-scenario.ts
@@ -12,7 +12,7 @@ async function tryLoadFromLocalStorage(
         const gameWorldId = 'game_world:' + id
         const gameWorld: GameWorld = {
             stats: [],
-            cards: {},
+            cards: [],
             defaultState: {
                 state: {},
                 flags: {},


### PR DESCRIPTION
- Simplify content types to match https://github.com/Muthaias/swipeforfuture-content/pull/22
- Delete EventCard related logic
- Implement linked cards
- Update game engine to use new content types
- Add feature to game engine to sort available cards by priority. This allows event cards to appear with higher priority than regular cards.

Resolves #165